### PR TITLE
Added enableAntiAffinity in instance spec

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -93,6 +93,8 @@ type InstanceSpec struct {
 	InstanceCount        int32                           `json:"instanceCount,omitempty"`
 	Locations            []LocationSpec                  `json:"locations,omitempty"`
 	VolumeClaimTemplates []EmbeddedPersistentVolumeClaim `json:"volumeClaimTemplates,omitempty"`
+	// Enables pod anti affinity
+	EnableAntiAffinity bool `json:"enableAntiAffinity,omitempty"`
 }
 
 type MastersSpec struct {

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -92,6 +92,9 @@ spec:
                   instanceGroup:
                     description: label filter (for daemonset)
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -2072,6 +2075,9 @@ spec:
                   instanceGroup:
                     description: label filter (for daemonset) use host network
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -4050,6 +4056,9 @@ spec:
                   instanceGroup:
                     description: label filter (for daemonset)
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -6028,6 +6037,9 @@ spec:
                   instanceGroup:
                     description: label filter (for daemonset)
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -8009,6 +8021,9 @@ spec:
                 properties:
                   instanceGroup:
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -10003,6 +10018,9 @@ spec:
                 properties:
                   instanceGroup:
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -11980,6 +11998,9 @@ spec:
                 properties:
                   instanceGroup:
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -13957,6 +13978,9 @@ spec:
                 properties:
                   instanceGroup:
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -15935,6 +15959,9 @@ spec:
                   instanceGroup:
                     description: label filter (for daemonset)
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -17920,6 +17947,9 @@ spec:
                   instanceGroup:
                     description: label filter (for daemonset)
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -19952,6 +19982,9 @@ spec:
                 properties:
                   instanceGroup:
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer

--- a/pkg/components/server.go
+++ b/pkg/components/server.go
@@ -2,6 +2,8 @@ package components
 
 import (
 	"context"
+	"path"
+
 	ytv1 "github.com/YTsaurus/yt-k8s-operator/api/v1"
 	"github.com/YTsaurus/yt-k8s-operator/pkg/apiproxy"
 	"github.com/YTsaurus/yt-k8s-operator/pkg/consts"
@@ -11,7 +13,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"path"
 )
 
 // Server represents a typical YT cluster server component, like master or scheduler.
@@ -132,7 +133,7 @@ func (s *Server) BuildStatefulSet() *appsv1.StatefulSet {
 		Volumes: createVolumes(s.instanceSpec.Volumes, s.labeller.GetMainConfigMapName()),
 	}
 
-	if s.enableAntiAffinity {
+	if s.enableAntiAffinity || s.instanceSpec.EnableAntiAffinity {
 		affinity := corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/ytop-chart/templates/ytsaurus-crd.yaml
+++ b/ytop-chart/templates/ytsaurus-crd.yaml
@@ -92,6 +92,9 @@ spec:
                   instanceGroup:
                     description: label filter (for daemonset)
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -2030,6 +2033,9 @@ spec:
                   instanceGroup:
                     description: label filter (for daemonset) use host network
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -3966,6 +3972,9 @@ spec:
                   instanceGroup:
                     description: label filter (for daemonset)
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -5902,6 +5911,9 @@ spec:
                   instanceGroup:
                     description: label filter (for daemonset)
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -7841,6 +7853,9 @@ spec:
                 properties:
                   instanceGroup:
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -9793,6 +9808,9 @@ spec:
                 properties:
                   instanceGroup:
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -11729,6 +11747,9 @@ spec:
                   instanceGroup:
                     description: label filter (for daemonset)
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer
@@ -13665,6 +13686,9 @@ spec:
                   instanceGroup:
                     description: label filter (for daemonset)
                     properties:
+                      enableAntiAffinity:
+                        description: Enables pod anti affinity
+                        type: boolean
                       instanceCount:
                         format: int32
                         type: integer


### PR DESCRIPTION
Add enableAntiAffinity flag for instanceSpec, so it's possible to enable anti affinity for any node (not only for master nodes). Also, might be useful to add whole corev1.Affinity in InstanceSpec.