### PR TITLE
Remove probably wrong build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 
 RUN mkdir -p /home/psushin/work/
-COPY ./ytsaurus.tech ./ytsaurus.tech
 
 RUN go mod download
 


### PR DESCRIPTION
Without this patch, I'm getting this build error
```
[+] Building 1.1s (13/20)                                                                                                                                                                      
 => [internal] load build definition from Dockerfile                                                                                                                                      0.0s
 => => transferring dockerfile: 904B                                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                         0.0s
 => => transferring context: 172B                                                                                                                                                         0.0s
 => [internal] load metadata for gcr.io/distroless/static:nonroot                                                                                                                         0.6s
 => [internal] load metadata for docker.io/library/golang:1.18                                                                                                                            1.1s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                             0.0s
 => [internal] load build context                                                                                                                                                         0.0s
 => => transferring context: 18.52kB                                                                                                                                                      0.0s
 => [builder  1/12] FROM docker.io/library/golang:1.18@sha256:50c889275d26f816b5314fc99f55425fa76b18fcaf16af255f5d57f09e1f48da                                                            0.0s
 => [stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:149531e38c7e4554d4a6725d7d70593ef9f9881358809463800669ac89f3b0ec                                                           0.0s
 => CACHED [builder  2/12] WORKDIR /workspace                                                                                                                                             0.0s
 => CACHED [builder  3/12] COPY go.mod go.mod                                                                                                                                             0.0s
 => CACHED [builder  4/12] COPY go.sum go.sum                                                                                                                                             0.0s
 => CACHED [builder  5/12] RUN mkdir -p /home/psushin/work/                                                                                                                               0.0s
 => ERROR [builder  6/12] COPY ./ytsaurus.tech ./ytsaurus.tech                                                                                                                            0.0s
------
 > [builder  6/12] COPY ./ytsaurus.tech ./ytsaurus.tech:
------
Dockerfile:14
--------------------
  12 |     
  13 |     RUN mkdir -p /home/psushin/work/
  14 | >>> COPY ./ytsaurus.tech ./ytsaurus.tech
  15 |     
  16 |     RUN go mod download
--------------------
ERROR: failed to solve: failed to compute cache key: failed to calculate checksum of ref moby::dcmfpqxr6eawpdfjucnkygkha: "/ytsaurus.tech": not found
make: *** [Makefile:73: docker-build] Error 1
```

Error message makes sense since there is no `ytsaurus.tech` in the repository

P.S. I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru