### PR TITLE
fix: nil map assignment

### DIFF
--- a/api/v1/ytsaurus_webhook.go
+++ b/api/v1/ytsaurus_webhook.go
@@ -61,8 +61,8 @@ var _ webhook.Validator = &Ytsaurus{}
 func (r *Ytsaurus) validateProxies(spec YtsaurusSpec) field.ErrorList {
 	var allErrs field.ErrorList
 
-	var httpRoles map[string]bool
-	var rpcRoles map[string]bool
+	httpRoles := map[string]bool{}
+	rpcRoles := map[string]bool{}
 	hasDefaultHTTPProxy := false
 	for _, hp := range spec.HTTPProxies {
 		if _, exists := httpRoles[hp.Role]; exists {


### PR DESCRIPTION
```
2023/06/13 14:26:38 http: panic serving 10.244.0.149:37554: assignment to entry in nil map
goroutine 4279 [running]:
net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1825 +0xbf
panic({0x1674d00, 0x1abfb40})
        /usr/local/go/src/runtime/panic.go:844 +0x258
github.com/ytsaurus/yt-k8s-operator/api/v1.(*Ytsaurus).validateProxies(_, {{0xc0008a1120, 0x20}, {0xc000528d20, 0x12}, {0x0, 0x0, 0x0}, 0xc0005d8550, 0x0, ...})
        /workspace/api/v1/ytsaurus_webhook.go:74 +0x9f5
github.com/ytsaurus/yt-k8s-operator/api/v1.(*Ytsaurus).validateYtsaurus(0xc000601000)
        /workspace/api/v1/ytsaurus_webhook.go:96 +0xa5
github.com/ytsaurus/yt-k8s-operator/api/v1.(*Ytsaurus).ValidateCreate(0xc000601000)
        /workspace/api/v1/ytsaurus_webhook.go:111 +0xbe
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*validatingHandler).Handle(_, {_, _}, {{{0xc0006cef90, 0x24}, {{0xc000528c18, 0x15}, {0xc0006b38a0, 0x2}, {0xc0006b38a8, ...}}, ...}})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/webhook/admission/validator.go:71 +0x239
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle(_, {_, _}, {{{0xc0006cef90, 0x24}, {{0xc000528c18, 0x15}, {0xc0006b38a0, 0x2}, {0xc0006b38a8, ...}}, ...}})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/webhook/admission/webhook.go:146 +0xa2
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP(0xc00003acc0, {0x7ff14385c360?, 0xc000a1b4f0}, 0xc000530700)
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.2/pkg/webhook/admission/http.go:98 +0xe90
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerInFlight.func1({0x7ff14385c360, 0xc000a1b4f0}, 0x1ad7700?)
        /go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/promhttp/instrument_server.go:40 +0xd4
net/http.HandlerFunc.ServeHTTP(0x1ad7760?, {0x7ff14385c360?, 0xc000a1b4f0?}, 0xc0000a5a38?)
        /usr/local/go/src/net/http/server.go:2084 +0x2f
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1({0x1ad7760?, 0xc00016c1c0?}, 0xc000530700)
        /go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/promhttp/instrument_server.go:117 +0xaa
net/http.HandlerFunc.ServeHTTP(0x26e9da0?, {0x1ad7760?, 0xc00016c1c0?}, 0xc0000a59c0?)
        /usr/local/go/src/net/http/server.go:2084 +0x2f
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2({0x1ad7760, 0xc00016c1c0}, 0xc000530700)
        /go/pkg/mod/github.com/prometheus/client_golang@v1.12.1/prometheus/promhttp/instrument_server.go:84 +0xbf
net/http.HandlerFunc.ServeHTTP(0x207c416c361?, {0x1ad7760?, 0xc00016c1c0?}, 0xc000616d00?)
        /usr/local/go/src/net/http/server.go:2084 +0x2f
net/http.(*ServeMux).ServeHTTP(0xc000149161?, {0x1ad7760, 0xc00016c1c0}, 0xc000530700)
        /usr/local/go/src/net/http/server.go:2462 +0x149
net/http.serverHandler.ServeHTTP({0x1acac18?}, {0x1ad7760, 0xc00016c1c0}, 0xc000530700)
        /usr/local/go/src/net/http/server.go:2916 +0x43b
net/http.(*conn).serve(0xc0003aa5a0, {0x1ad85a8, 0xc000a085a0})
        /usr/local/go/src/net/http/server.go:1966 +0x5d7
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:3071 +0x4db

```

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en