### PR TITLE
Add Support for Different Media Types to ytsaurus Kubernetes Operator

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -260,11 +260,14 @@ type DeprecatedSpytSpec struct {
 	SpytVersion  string `json:"spytVersion,omitempty"`
 }
 
+type Medium struct {
+	Name string `yson:"name"`
+}
+
 // YtsaurusSpec defines the desired state of Ytsaurus
 type YtsaurusSpec struct {
-	CoreImage string `json:"coreImage,omitempty"`
-	UIImage   string `json:"uiImage,omitempty"`
-
+	CoreImage        string                        `json:"coreImage,omitempty"`
+	UIImage          string                        `json:"uiImage,omitempty"`
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	ConfigOverrides  *corev1.LocalObjectReference  `json:"configOverrides,omitempty"`
 	AdminCredentials *corev1.LocalObjectReference  `json:"adminCredentials,omitempty"`

--- a/pkg/components/init_job.go
+++ b/pkg/components/init_job.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"strings"
 
 	"github.com/ytsaurus/yt-k8s-operator/pkg/apiproxy"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/consts"

--- a/pkg/components/query_tracker.go
+++ b/pkg/components/query_tracker.go
@@ -3,6 +3,7 @@ package components
 import (
 	"context"
 	"fmt"
+
 	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/apiproxy"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/consts"

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -480,3 +480,25 @@ func (g *Generator) GetDiscoveryConfig() ([]byte, error) {
 	}
 	return marshallYsonConfig(c)
 }
+
+func (g *Generator) GetExtraMedia() []v1.Medium {
+	mediaMap := make(map[string]v1.Medium)
+
+	for _, d := range g.ytsaurus.Spec.DataNodes {
+		for _, l := range d.Locations {
+			if l.Medium == "default" {
+				continue
+			}
+			mediaMap[l.Medium] = v1.Medium{
+				Name: l.Medium,
+			}
+		}
+	}
+
+	mediaSlice := make([]v1.Medium, 0, len(mediaMap))
+	for _, v := range mediaMap {
+		mediaSlice = append(mediaSlice, v)
+	}
+
+	return mediaSlice
+}


### PR DESCRIPTION
This pull request introduces the ability to handle different media types in the ytsaurus Kubernetes operator. 

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
