### PR TITLE
Fix e2e

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -75,10 +75,10 @@ jobs:
           kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
 
           make helm-kind-install
-          docker pull ytsaurus/ytsaurus-nightly:dev-23.1-relwithdebinfo-5f8638fc66f6e59c7a06708ed508804986a6579f
-          kind load docker-image ytsaurus/ytsaurus-nightly:dev-23.1-relwithdebinfo-5f8638fc66f6e59c7a06708ed508804986a6579f
-          docker pull ytsaurus/ytsaurus-nightly:dev-23.1-relwithdebinfo-9779e0140ff73f5a786bd5362313ef9a74fcd0de
-          kind load docker-image ytsaurus/ytsaurus-nightly:dev-23.1-relwithdebinfo-9779e0140ff73f5a786bd5362313ef9a74fcd0de
+          docker pull ytsaurus/ytsaurus-nightly:dev-23.1-5f8638fc66f6e59c7a06708ed508804986a6579f
+          kind load docker-image ytsaurus/ytsaurus-nightly:dev-23.1-5f8638fc66f6e59c7a06708ed508804986a6579f
+          docker pull ytsaurus/ytsaurus-nightly:dev-23.1-9779e0140ff73f5a786bd5362313ef9a74fcd0de
+          kind load docker-image ytsaurus/ytsaurus-nightly:dev-23.1-9779e0140ff73f5a786bd5362313ef9a74fcd0de
           YTSAURUS_ENABLE_E2E_TESTS=true make test
           helm uninstall ytsaurus
 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,7 +1,6 @@
 name: Build and test
 
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,6 +1,7 @@
 name: Build and test
 
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -76,10 +76,10 @@ jobs:
           kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
 
           make helm-kind-install
-          docker pull ytsaurus/ytsaurus-nightly:dev-864e613b6261e2458fbee05f1a440d4b277c9ee6
-          kind load docker-image ytsaurus/ytsaurus-nightly:dev-864e613b6261e2458fbee05f1a440d4b277c9ee6
-          docker pull ytsaurus/ytsaurus-nightly:dev-4526e114f0d15afdd3b7448f65e49abdfb084de9
-          kind load docker-image ytsaurus/ytsaurus-nightly:dev-4526e114f0d15afdd3b7448f65e49abdfb084de9
+          docker pull ytsaurus/ytsaurus-nightly:dev-23.1-relwithdebinfo-5f8638fc66f6e59c7a06708ed508804986a6579f
+          kind load docker-image ytsaurus/ytsaurus-nightly:dev-23.1-relwithdebinfo-5f8638fc66f6e59c7a06708ed508804986a6579f
+          docker pull ytsaurus/ytsaurus-nightly:dev-23.1-relwithdebinfo-9779e0140ff73f5a786bd5362313ef9a74fcd0de
+          kind load docker-image ytsaurus/ytsaurus-nightly:dev-23.1-relwithdebinfo-9779e0140ff73f5a786bd5362313ef9a74fcd0de
           YTSAURUS_ENABLE_E2E_TESTS=true make test
           helm uninstall ytsaurus
 

--- a/api/v1/test_helpers.go
+++ b/api/v1/test_helpers.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	YtsaurusName    = "test-ytsaurus"
-	CoreImageFirst  = "ytsaurus/ytsaurus-nightly:dev-864e613b6261e2458fbee05f1a440d4b277c9ee6"
-	CoreImageSecond = "ytsaurus/ytsaurus-nightly:dev-4526e114f0d15afdd3b7448f65e49abdfb084de9"
+	CoreImageFirst  = "ytsaurus/ytsaurus-nightly:dev-23.1-relwithdebinfo-5f8638fc66f6e59c7a06708ed508804986a6579f"
+	CoreImageSecond = "ytsaurus/ytsaurus-nightly:dev-23.1-relwithdebinfo-9779e0140ff73f5a786bd5362313ef9a74fcd0de"
 )
 
 func CreateBaseYtsaurusResource(namespace string) *Ytsaurus {

--- a/api/v1/test_helpers.go
+++ b/api/v1/test_helpers.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	YtsaurusName    = "test-ytsaurus"
-	CoreImageFirst  = "ytsaurus/ytsaurus-nightly:dev-23.1-relwithdebinfo-5f8638fc66f6e59c7a06708ed508804986a6579f"
-	CoreImageSecond = "ytsaurus/ytsaurus-nightly:dev-23.1-relwithdebinfo-9779e0140ff73f5a786bd5362313ef9a74fcd0de"
+	CoreImageFirst  = "ytsaurus/ytsaurus-nightly:dev-23.1-5f8638fc66f6e59c7a06708ed508804986a6579f"
+	CoreImageSecond = "ytsaurus/ytsaurus-nightly:dev-23.1-9779e0140ff73f5a786bd5362313ef9a74fcd0de"
 )
 
 func CreateBaseYtsaurusResource(namespace string) *Ytsaurus {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Fixing https://github.com/ytsaurus/yt-k8s-operator/actions/runs/7087229265/job/19287119945

Current images end up with error 
```
+++ /usr/bin/ytserver-all --version
+++ head -c4
++ export YTSAURUS_VERSION=23.2
++ YTSAURUS_VERSION=23.2
++ export YT_LOG_LEVEL=DEBUG
++ YT_LOG_LEVEL=DEBUG
++ [[ 23.2 < 23.2 ]]
++ /usr/bin/yt execute master_exit_read_only '{}'
Command master_exit_read_only is not supported
```
because they are pre-23.2-release (though consider themselves as 23.2), but master_exit_read_only is not yet implemented in that versions.


With new 23.1 versions test works:
```
=== RUN   TestAPIs
Running Suite: Controller Suite
===============================
Random Seed: 1701859770
Will run 3 of 3 specs

• [SLOW TEST:289.126 seconds]
Basic test for Ytsaurus controller
/home/sibirev/yt-k8s-operator-l0kix2/controllers/ytsaurus_controller_test.go:174
  When setting up the test environment
  /home/sibirev/yt-k8s-operator-l0kix2/controllers/ytsaurus_controller_test.go:175
    Should run and update Ytsaurus
    /home/sibirev/yt-k8s-operator-l0kix2/controllers/ytsaurus_controller_test.go:176
------------------------------
• [SLOW TEST:94.123 seconds]
Basic test for Ytsaurus controller
/home/sibirev/yt-k8s-operator-l0kix2/controllers/ytsaurus_controller_test.go:174
  When setting up the test environment
  /home/sibirev/yt-k8s-operator-l0kix2/controllers/ytsaurus_controller_test.go:175
    Should run and try to update Ytsaurus with tablet cell bundle which is not in `good` health
    /home/sibirev/yt-k8s-operator-l0kix2/controllers/ytsaurus_controller_test.go:238
------------------------------
• [SLOW TEST:77.450 seconds]
Basic test for Ytsaurus controller
/home/sibirev/yt-k8s-operator-l0kix2/controllers/ytsaurus_controller_test.go:174
  When setting up the test environment
  /home/sibirev/yt-k8s-operator-l0kix2/controllers/ytsaurus_controller_test.go:175
    Should run and try to update Ytsaurus with lvc
    /home/sibirev/yt-k8s-operator-l0kix2/controllers/ytsaurus_controller_test.go:287
------------------------------


Ran 3 of 3 Specs in 461.914 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 0 Skipped
```