### PR TITLE
e2e test for 23.1 > 23.2 update

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -79,6 +79,8 @@ jobs:
           kind load docker-image ytsaurus/ytsaurus-nightly:dev-23.1-5f8638fc66f6e59c7a06708ed508804986a6579f
           docker pull ytsaurus/ytsaurus-nightly:dev-23.1-9779e0140ff73f5a786bd5362313ef9a74fcd0de
           kind load docker-image ytsaurus/ytsaurus-nightly:dev-23.1-9779e0140ff73f5a786bd5362313ef9a74fcd0de
+          docker pull ytsaurus/ytsaurus-nightly:dev-23.2-62a472c4efc2c8395d125a13ca0216720e06999d
+          kind load docker-image ytsaurus/ytsaurus-nightly:dev-23.2-62a472c4efc2c8395d125a13ca0216720e06999d
           YTSAURUS_ENABLE_E2E_TESTS=true make test
           helm uninstall ytsaurus
 

--- a/api/v1/test_helpers.go
+++ b/api/v1/test_helpers.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	YtsaurusName    = "test-ytsaurus"
-	CoreImageFirst  = "ytsaurus/ytsaurus-nightly:dev-23.1-5f8638fc66f6e59c7a06708ed508804986a6579f"
-	CoreImageSecond = "ytsaurus/ytsaurus-nightly:dev-23.1-9779e0140ff73f5a786bd5362313ef9a74fcd0de"
+	YtsaurusName     = "test-ytsaurus"
+	CoreImageFirst   = "ytsaurus/ytsaurus-nightly:dev-23.1-5f8638fc66f6e59c7a06708ed508804986a6579f"
+	CoreImageSecond  = "ytsaurus/ytsaurus-nightly:dev-23.1-9779e0140ff73f5a786bd5362313ef9a74fcd0de"
+	CoreImageNextVer = "ytsaurus/ytsaurus-nightly:dev-23.2-62a472c4efc2c8395d125a13ca0216720e06999d"
 )
 
 func CreateBaseYtsaurusResource(namespace string) *Ytsaurus {

--- a/controllers/ytsaurus_controller_test.go
+++ b/controllers/ytsaurus_controller_test.go
@@ -174,11 +174,11 @@ type testRow struct {
 var _ = Describe("Basic test for Ytsaurus controller", func() {
 	Context("When setting up the test environment", func() {
 		It(
-			"Should run and update Ytsaurus to the same minor version",
+			"Should run and update Ytsaurus within same major version",
 			getSimpleUpdateScenario("test1", ytv1.CoreImageSecond),
 		)
 		It(
-			"Should run and update Ytsaurus to the next minor version",
+			"Should run and update Ytsaurus to the next major version",
 			getSimpleUpdateScenario("test2", ytv1.CoreImageNextVer),
 		)
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Add e2e to check that updating from 23.1 to 23.2 (and master_exit_read_only job) works.