### PR TITLE
Add access control object namespace "queries" and object "nobody" during init

### DIFF
--- a/controllers/ytsaurus_controller_test.go
+++ b/controllers/ytsaurus_controller_test.go
@@ -281,6 +281,35 @@ var _ = Describe("Basic test for Ytsaurus controller", func() {
 
 			runImpossibleUpdateAndRollback(ytsaurus, ytClient)
 		})
+
+		It("Should run with query tracker and check that access control object namespace 'queries' and object 'nobody' exists", func() {
+			By("Creating a Ytsaurus resource")
+			ctx := context.Background()
+
+			namespace := "querytrackeraco"
+
+			ytsaurus := ytv1.CreateBaseYtsaurusResource(namespace)
+			ytsaurus.Spec.TabletNodes = []ytv1.TabletNodesSpec{
+				{
+					InstanceSpec: ytv1.InstanceSpec{InstanceCount: 1},
+				},
+			}
+			ytsaurus.Spec.QueryTrackers = &ytv1.QueryTrackerSpec{InstanceSpec: ytv1.InstanceSpec{InstanceCount: 1}}
+
+			g := ytconfig.NewGenerator(ytsaurus, "local")
+
+			defer deleteYtsaurus(ctx, ytsaurus)
+			runYtsaurus(ytsaurus)
+
+			By("Creating ytsaurus client")
+			ytClient := getYtClient(g, namespace)
+
+			By("Check that access control object namespace 'queries' exists")
+			Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries"), nil)).Should(Equal(true))
+
+			By("Check that access control object 'nobody' in namespace 'queries' exists")
+			Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries/nobody"), nil)).Should(Equal(true))
+		})
 	})
 
 })

--- a/pkg/components/query_tracker.go
+++ b/pkg/components/query_tracker.go
@@ -287,6 +287,37 @@ func (qt *queryTracker) init(ctx context.Context, ytClient yt.Client) (err error
 		logger.Error(err, fmt.Sprintf("Setting '//sys/clusters/%s' failed", qt.labeller.GetClusterName()))
 		return
 	}
+
+	_, err = ytClient.CreateObject(
+		ctx,
+		yt.NodeAccessControlObjectNamespace,
+		&yt.CreateObjectOptions{
+			Attributes: map[string]interface{}{
+				"name": "queries",
+			},
+			IgnoreExisting: true,
+		},
+	)
+	if err != nil {
+		logger.Error(err, "Creating access control object namespace 'queries' failed")
+		return
+	}
+
+	_, err = ytClient.CreateObject(
+		ctx,
+		yt.NodeAccessControlObject,
+		&yt.CreateObjectOptions{
+			Attributes: map[string]interface{}{
+				"name":      "nobody",
+				"namespace": "queries",
+			},
+			IgnoreExisting: true,
+		},
+	)
+	if err != nil {
+		logger.Error(err, "Creating access control object 'nobody' in namespace 'queries' failed")
+		return
+	}
 	return
 }
 


### PR DESCRIPTION
We implemented server side changes according to https://github.com/ytsaurus/ytsaurus/issues/175 proposal

They assume existence of "queries" access control object namespace and "nobody" access control object in a cluster.

Adding creation of these objects during query tracker init job

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
