### PR TITLE
Increase memory for operator container

### DIFF
--- a/ytop-chart/values.yaml
+++ b/ytop-chart/values.yaml
@@ -40,10 +40,10 @@ controllerManager:
     resources:
       limits:
         cpu: 500m
-        memory: 128Mi
+        memory: 512Mi
       requests:
         cpu: 10m
-        memory: 64Mi
+        memory: 512Mi
   replicas: 1
   serviceAccount:
     annotations: {}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Currently operator memory usage can be more than 256mb while updating cluster and it OOMs sometimes.
![image](https://github.com/ytsaurus/yt-k8s-operator/assets/578057/2bc6dbc9-1b02-404e-b33d-10bac9029de1)


Created research issue #91.