### PR TITLE
Support local k8s port forwarding in E2E

### DIFF
--- a/api/v1/test_helpers.go
+++ b/api/v1/test_helpers.go
@@ -1,6 +1,9 @@
 package v1
 
 import (
+	"os"
+	"strconv"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -96,12 +99,7 @@ func CreateBaseYtsaurusResource(namespace string) *Ytsaurus {
 				},
 			},
 			HTTPProxies: []HTTPProxiesSpec{
-				{
-					ServiceType: "NodePort",
-					InstanceSpec: InstanceSpec{
-						InstanceCount: 1,
-					},
-				},
+				createHTTPProxiesSpec(),
 			},
 			DataNodes: []DataNodesSpec{
 				{
@@ -208,4 +206,23 @@ func CreateBaseYtsaurusResource(namespace string) *Ytsaurus {
 			},
 		},
 	}
+}
+
+func createHTTPProxiesSpec() HTTPProxiesSpec {
+	spec := HTTPProxiesSpec{
+		ServiceType: "NodePort",
+		InstanceSpec: InstanceSpec{
+			InstanceCount: 1,
+		},
+	}
+	portStr := os.Getenv("E2E_HTTP_PROXY_INTERNAL_PORT")
+	if portStr != "" {
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			panic("Invalid E2E_HTTP_PROXY_INTERNAL_PORT value")
+		}
+		portInt32 := int32(port)
+		spec.HttpNodePort = &portInt32
+	}
+	return spec
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Currently E2E tests are only work on linux. It is impossible (or I couldn't find a way) to access internal container port (yt http proxy being specifically) from localhost which is not exposed. Though it is possible for mac with port-forwarding. 

So here I've added possibility to specify internal port for http proxy pod in `E2E_HTTP_PROXY_INTERNAL_PORT` env var and localhost yt proxy using `E2E_YT_PROXY` env var. That way if env vars configured consistently with port forwarding test can be run on mac os.

Current tests behaviour is left unchanged.