### PR TITLE
Master update issue repro test

### DIFF
--- a/api/v1/test_helpers.go
+++ b/api/v1/test_helpers.go
@@ -14,11 +14,8 @@ const (
 	CoreImageNextVer = "ytsaurus/ytsaurus-nightly:dev-23.2-62a472c4efc2c8395d125a13ca0216720e06999d"
 )
 
-func CreateBaseYtsaurusResource(namespace string) *Ytsaurus {
+func CreateMinimalYtsaurusResource(namespace string) *Ytsaurus {
 	masterVolumeSize, _ := resource.ParseQuantity("5Gi")
-	execNodeVolumeSize, _ := resource.ParseQuantity("3Gi")
-	execNodeCPU, _ := resource.ParseQuantity("1")
-	execNodeMemory, _ := resource.ParseQuantity("2Gi")
 
 	return &Ytsaurus{
 		ObjectMeta: metav1.ObjectMeta{
@@ -30,11 +27,6 @@ func CreateBaseYtsaurusResource(namespace string) *Ytsaurus {
 			IsManaged:        true,
 			UseShortNames:    true,
 			CoreImage:        CoreImageFirst,
-			Discovery: DiscoverySpec{
-				InstanceSpec: InstanceSpec{
-					InstanceCount: 1,
-				},
-			},
 			Bootstrap: &BootstrapSpec{
 				TabletCellBundles: &BundlesBootstrapSpec{
 					Sys: &BundleBootstrapSpec{
@@ -103,51 +95,6 @@ func CreateBaseYtsaurusResource(namespace string) *Ytsaurus {
 					},
 				},
 			},
-			DataNodes: []DataNodesSpec{
-				{
-					InstanceSpec: InstanceSpec{
-						InstanceCount: 3,
-						Locations: []LocationSpec{
-							{
-								LocationType: "ChunkStore",
-								Path:         "/yt/node-data/chunk-store",
-							},
-						},
-						Volumes: []corev1.Volume{
-							{
-								Name: "node-data",
-								VolumeSource: corev1.VolumeSource{
-									EmptyDir: &corev1.EmptyDirVolumeSource{
-										SizeLimit: &masterVolumeSize,
-									},
-								},
-							},
-						},
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "node-data",
-								MountPath: "/yt/node-data",
-							},
-						},
-					},
-				},
-			},
-			TabletNodes: []TabletNodesSpec{
-				{
-					InstanceSpec: InstanceSpec{
-						InstanceCount: 3,
-						Loggers: []TextLoggerSpec{
-							{
-								BaseLoggerSpec: BaseLoggerSpec{
-									MinLogLevel: LogLevelDebug,
-									Name:        "debug",
-								},
-								WriterType: LogWriterTypeFile,
-							},
-						},
-					},
-				},
-			},
 			Schedulers: &SchedulersSpec{
 				InstanceSpec: InstanceSpec{
 					InstanceCount: 1,
@@ -158,54 +105,115 @@ func CreateBaseYtsaurusResource(namespace string) *Ytsaurus {
 					InstanceCount: 1,
 				},
 			},
-			ExecNodes: []ExecNodesSpec{
-				{
-					InstanceSpec: InstanceSpec{
-						InstanceCount: 1,
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    execNodeCPU,
-								corev1.ResourceMemory: execNodeMemory,
+		},
+	}
+}
+
+func CreateBaseYtsaurusResource(namespace string) *Ytsaurus {
+	ytsaurus := CreateMinimalYtsaurusResource(namespace)
+
+	masterVolumeSize, _ := resource.ParseQuantity("5Gi")
+	execNodeVolumeSize, _ := resource.ParseQuantity("3Gi")
+	execNodeCPU, _ := resource.ParseQuantity("1")
+	execNodeMemory, _ := resource.ParseQuantity("2Gi")
+
+	ytsaurus.Spec.Discovery = DiscoverySpec{
+		InstanceSpec: InstanceSpec{
+			InstanceCount: 1,
+		},
+	}
+	ytsaurus.Spec.DataNodes = []DataNodesSpec{
+		{
+			InstanceSpec: InstanceSpec{
+				InstanceCount: 3,
+				Locations: []LocationSpec{
+					{
+						LocationType: "ChunkStore",
+						Path:         "/yt/node-data/chunk-store",
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "node-data",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{
+								SizeLimit: &masterVolumeSize,
 							},
 						},
-						Loggers: []TextLoggerSpec{
-							{
-								BaseLoggerSpec: BaseLoggerSpec{
-									MinLogLevel: LogLevelDebug,
-									Name:        "debug",
-								},
-								WriterType: LogWriterTypeFile,
-							},
-						},
-						Locations: []LocationSpec{
-							{
-								LocationType: "ChunkCache",
-								Path:         "/yt/node-data/chunk-cache",
-							},
-							{
-								LocationType: "Slots",
-								Path:         "/yt/node-data/slots",
-							},
-						},
-						Volumes: []corev1.Volume{
-							{
-								Name: "node-data",
-								VolumeSource: corev1.VolumeSource{
-									EmptyDir: &corev1.EmptyDirVolumeSource{
-										SizeLimit: &execNodeVolumeSize,
-									},
-								},
-							},
-						},
-						VolumeMounts: []corev1.VolumeMount{
-							{
-								Name:      "node-data",
-								MountPath: "/yt/node-data",
-							},
-						},
+					},
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "node-data",
+						MountPath: "/yt/node-data",
 					},
 				},
 			},
 		},
 	}
+	ytsaurus.Spec.TabletNodes = []TabletNodesSpec{
+		{
+			InstanceSpec: InstanceSpec{
+				InstanceCount: 3,
+				Loggers: []TextLoggerSpec{
+					{
+						BaseLoggerSpec: BaseLoggerSpec{
+							MinLogLevel: LogLevelDebug,
+							Name:        "debug",
+						},
+						WriterType: LogWriterTypeFile,
+					},
+				},
+			},
+		},
+	}
+	ytsaurus.Spec.ExecNodes = []ExecNodesSpec{
+		{
+			InstanceSpec: InstanceSpec{
+				InstanceCount: 1,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    execNodeCPU,
+						corev1.ResourceMemory: execNodeMemory,
+					},
+				},
+				Loggers: []TextLoggerSpec{
+					{
+						BaseLoggerSpec: BaseLoggerSpec{
+							MinLogLevel: LogLevelDebug,
+							Name:        "debug",
+						},
+						WriterType: LogWriterTypeFile,
+					},
+				},
+				Locations: []LocationSpec{
+					{
+						LocationType: "ChunkCache",
+						Path:         "/yt/node-data/chunk-cache",
+					},
+					{
+						LocationType: "Slots",
+						Path:         "/yt/node-data/slots",
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "node-data",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{
+								SizeLimit: &execNodeVolumeSize,
+							},
+						},
+					},
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "node-data",
+						MountPath: "/yt/node-data",
+					},
+				},
+			},
+		},
+	}
+	return ytsaurus
 }

--- a/controllers/ytsaurus_controller_test.go
+++ b/controllers/ytsaurus_controller_test.go
@@ -37,12 +37,9 @@ func getYtClient(g *ytconfig.Generator, namespace string) yt.Client {
 	port := httpProxyService.Spec.Ports[0].NodePort
 
 	k8sNode := corev1.Node{}
-	kindClusterName := os.Getenv("KIND_CLUSTER_NAME")
-	if kindClusterName == "" {
-		kindClusterName = "kind"
-	}
+
 	Expect(k8sClient.Get(ctx,
-		types.NamespacedName{Name: kindClusterName + "-control-plane", Namespace: namespace},
+		types.NamespacedName{Name: getKindControlPlaneName(), Namespace: namespace},
 		&k8sNode),
 	).Should(Succeed())
 
@@ -61,6 +58,21 @@ func getYtClient(g *ytconfig.Generator, namespace string) yt.Client {
 	Expect(err).Should(Succeed())
 
 	return ytClient
+}
+
+func getKindControlPlaneName() string {
+	kindClusterName := os.Getenv("KIND_CLUSTER_NAME")
+	if kindClusterName == "" {
+		kindClusterName = "kind"
+	}
+	return kindClusterName + "-control-plane"
+}
+
+func getMasterPod(name, namespace string) corev1.Pod {
+	msPod := corev1.Pod{}
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &msPod)
+	Expect(err).Should(Succeed())
+	return msPod
 }
 
 func deleteYtsaurus(ctx context.Context, ytsaurus *ytv1.Ytsaurus) {
@@ -103,7 +115,17 @@ func runYtsaurus(ytsaurus *ytv1.Ytsaurus) {
 	}, timeout, interval).Should(BeTrue())
 
 	By("Check pods are running")
-	for _, podName := range []string{"ds-0", "ms-0", "hp-0", "dnd-0", "end-0"} {
+	pods := []string{"ms-0", "hp-0"}
+	if ytsaurus.Spec.Discovery.InstanceCount != 0 {
+		pods = append(pods, "ds-0")
+	}
+	if len(ytsaurus.Spec.DataNodes) != 0 {
+		pods = append(pods, "dnd-0")
+	}
+	if len(ytsaurus.Spec.ExecNodes) != 0 {
+		pods = append(pods, "end-0")
+	}
+	for _, podName := range pods {
 		Eventually(func() bool {
 			pod := &corev1.Pod{}
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: podName, Namespace: ytsaurus.Namespace}, pod)
@@ -182,11 +204,59 @@ var _ = Describe("Basic test for Ytsaurus controller", func() {
 			getSimpleUpdateScenario("test2", ytv1.CoreImageNextVer),
 		)
 
+		// This is a test for specific regression bug when master pods are recreated during PossibilityCheck stage.
+		It("Master shouldn't be recreated before WaitingForPodsCreation state if config changes", func() {
+			namespace := "test3"
+			ytsaurus := ytv1.CreateMinimalYtsaurusResource(namespace)
+			ytsaurusKey := types.NamespacedName{Name: ytv1.YtsaurusName, Namespace: namespace}
+
+			By("Creating a Ytsaurus resource")
+			ctx := context.Background()
+			g := ytconfig.NewGenerator(ytsaurus, "local")
+			defer deleteYtsaurus(ctx, ytsaurus)
+			runYtsaurus(ytsaurus)
+
+			By("Creating ytsaurus client")
+			ytClient := getYtClient(g, namespace)
+
+			By("Check that cluster alive")
+			res := make([]string, 0)
+			Expect(ytClient.ListNode(ctx, ypath.Path("/"), &res, nil)).Should(Succeed())
+
+			By("Store master pod creation time")
+			msPod := getMasterPod(g.GetMasterPodNames()[0], namespace)
+			podCreatedFirstTimestamp := msPod.CreationTimestamp
+
+			By("Run cluster update")
+			Expect(k8sClient.Get(ctx, ytsaurusKey, ytsaurus)).Should(Succeed())
+			ytsaurus.Spec.HostNetwork = true
+			ytsaurus.Spec.PrimaryMasters.HostAddresses = []string{
+				getKindControlPlaneName(),
+			}
+			Expect(k8sClient.Update(ctx, ytsaurus)).Should(Succeed())
+
+			By("Waiting Running")
+			Eventually(func() bool {
+				ytsaurus := &ytv1.Ytsaurus{}
+				err := k8sClient.Get(ctx, ytsaurusKey, ytsaurus)
+				if err != nil {
+					return false
+				}
+				return ytsaurus.Status.State == ytv1.ClusterStateUpdating &&
+					ytsaurus.Status.UpdateStatus.State == ytv1.UpdateStatePossibilityCheck
+			}, timeout, interval).Should(BeTrue())
+
+			By("Check that master pod was NOT recreated at the PossibilityCheck stage")
+			time.Sleep(1 * time.Second)
+			msPod = getMasterPod(g.GetMasterPodNames()[0], namespace)
+			Expect(podCreatedFirstTimestamp == msPod.CreationTimestamp).Should(BeTrue())
+		})
+
 		It("Should run and try to update Ytsaurus with tablet cell bundle which is not in `good` health", func() {
 			By("Creating a Ytsaurus resource")
 			ctx := context.Background()
 
-			namespace := "test3"
+			namespace := "test4"
 
 			ytsaurus := ytv1.CreateBaseYtsaurusResource(namespace)
 
@@ -235,7 +305,7 @@ var _ = Describe("Basic test for Ytsaurus controller", func() {
 			By("Creating a Ytsaurus resource")
 			ctx := context.Background()
 
-			namespace := "test4"
+			namespace := "test5"
 
 			ytsaurus := ytv1.CreateBaseYtsaurusResource(namespace)
 			ytsaurus.Spec.TabletNodes = make([]ytv1.TabletNodesSpec, 0)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

This PR fixes bug introduced [here](https://github.com/ytsaurus/yt-k8s-operator/pull/59/files#diff-e1fa7455a1e0e05be9402fe4a60a3aaecf2f0123f97155db009690ae77b02607R215) when master pods could be recreated during PossibilityCheck update state.
Test for repro is included, though master crashes on that unwanted restart in `PossibilityCheck`, but all works with the fix for some reason.

This PR just to show that test fails