### PR TITLE
Flow to run tests on Github resources

### DIFF
--- a/.github/workflows/check_all_pr.yaml
+++ b/.github/workflows/check_all_pr.yaml
@@ -1,0 +1,46 @@
+name: Build and test
+
+on:
+  pull_request:
+
+jobs:
+  e2e:
+    name: Run e2e test on KinD
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+
+      - name: checkout sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: run KinD
+        uses: helm/kind-action@v1.5.0
+        with:
+          cluster_name: kind
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.11.2
+
+      - name: Build
+        shell: bash
+        run: |
+          make build
+
+      - name: Run tests
+        shell: bash
+        run: |
+          kubectl get pod
+          make k8s-install-cert-manager
+          make helm-kind-install
+          make kind-load-test-images
+          YTSAURUS_ENABLE_E2E_TESTS=true make test
+          helm uninstall ytsaurus
+
+          ./compat_test.sh --from-version 0.4.1 --to-version trunk

--- a/.github/workflows/subflow_run_e2e.yaml
+++ b/.github/workflows/subflow_run_e2e.yaml
@@ -43,16 +43,10 @@ jobs:
           sudo mv ./kind /usr/local/bin/kind
           kind create cluster --retain -v 100
           kubectl get pod
-          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
+          make k8s-install-cert-manager
 
           make helm-kind-install
-          docker pull ytsaurus/ytsaurus-nightly:dev-23.1-5f8638fc66f6e59c7a06708ed508804986a6579f
-          kind load docker-image ytsaurus/ytsaurus-nightly:dev-23.1-5f8638fc66f6e59c7a06708ed508804986a6579f
-          docker pull ytsaurus/ytsaurus-nightly:dev-23.1-9779e0140ff73f5a786bd5362313ef9a74fcd0de
-          kind load docker-image ytsaurus/ytsaurus-nightly:dev-23.1-9779e0140ff73f5a786bd5362313ef9a74fcd0de
-          docker pull ytsaurus/ytsaurus-nightly:dev-23.2-62a472c4efc2c8395d125a13ca0216720e06999d
-          kind load docker-image ytsaurus/ytsaurus-nightly:dev-23.2-62a472c4efc2c8395d125a13ca0216720e06999d
-          YTSAURUS_ENABLE_E2E_TESTS=true make test
+          make kind-load-test-images
           helm uninstall ytsaurus
 
           ./compat_test.sh --from-version 0.4.1 --to-version trunk

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,18 @@ helm-kind-install: ## Install helm chart from sources in kind.
 	kind load docker-image ${OPERATOR_IMAGE}:${OPERATOR_TAG}
 	helm install ytsaurus $(OPERATOR_CHART)
 
+TEST_IMAGES = \
+	ytsaurus/ytsaurus-nightly:dev-23.1-5f8638fc66f6e59c7a06708ed508804986a6579f \
+	ytsaurus/ytsaurus-nightly:dev-23.1-9779e0140ff73f5a786bd5362313ef9a74fcd0de \
+	ytsaurus/ytsaurus-nightly:dev-23.2-62a472c4efc2c8395d125a13ca0216720e06999d
+.PHONY: kind-load-test-images
+kind-load-test-images:
+	$(foreach img,$(TEST_IMAGES),docker pull $(img) && kind load docker-image $(img);)
+
+.PHONY: k8s-install-cert-manager
+k8s-install-cert-manager:
+	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
+
 .PHONY: helm-minikube-install
 helm-minikube-install: helm ## Install helm chart from sources in minikube.
 	eval $$(minikube docker-env) && docker build -t ${OPERATOR_IMAGE}:${OPERATOR_TAG} .


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Move some common code from GH workflows to the Makefile and add new workflow, that runs tests at github (not yandex cloud) vms.
Unlike current flow this one can be run on all PRs (including forks) safely, because it is not using any secrets.
