### PR TITLE
Add lost e2e run in run_e2e_subflow

### DIFF
--- a/.github/workflows/subflow_run_e2e.yaml
+++ b/.github/workflows/subflow_run_e2e.yaml
@@ -47,6 +47,7 @@ jobs:
 
           make helm-kind-install
           make kind-load-test-images
+          YTSAURUS_ENABLE_E2E_TESTS=true make test
           helm uninstall ytsaurus
 
           ./compat_test.sh --from-version 0.4.1 --to-version trunk


### PR DESCRIPTION
I've accidently removed e2e run internal PR check in change introduced in https://github.com/ytsaurus/yt-k8s-operator/pull/102/files.
Fixing that.