### PR TITLE
Replace GH KinD step with manual install

### DIFF
--- a/.github/workflows/check_all_pr.yaml
+++ b/.github/workflows/check_all_pr.yaml
@@ -18,11 +18,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: run KinD
-        uses: helm/kind-action@v1.5.0
-        with:
-          cluster_name: kind
-
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
@@ -36,7 +31,12 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
+          [ $(uname -m) = x86_64 ] && curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.19.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind create cluster --retain -v 100
           kubectl get pod
+
           make k8s-install-cert-manager
           make helm-kind-install
           make kind-load-test-images


### PR DESCRIPTION
I've found some difference in dns resolving (in e2e test https://github.com/ytsaurus/yt-k8s-operator/pull/113) for version which is installed with helm/kind-action step, better switch to manual install which works more stable.