### PR TITLE
Add YT_LOG_LEVEL=debug to init ch_public script

### DIFF
--- a/pkg/components/chyt.go
+++ b/pkg/components/chyt.go
@@ -104,7 +104,7 @@ func (c *Chyt) createInitScript() string {
 func (c *Chyt) createInitChPublicScript() string {
 	script := []string{
 		initJobPrologue,
-		fmt.Sprintf("export YT_PROXY=%v CHYT_CTL_ADDRESS=%v", c.cfgen.GetHTTPProxiesAddress(consts.DefaultHTTPProxyRole), c.cfgen.GetStrawberryControllerServiceAddress()),
+		fmt.Sprintf("export YT_PROXY=%v CHYT_CTL_ADDRESS=%v YT_LOG_LEVEL=debug", c.cfgen.GetHTTPProxiesAddress(consts.DefaultHTTPProxyRole), c.cfgen.GetStrawberryControllerServiceAddress()),
 		"yt create scheduler_pool --attributes '{name=chyt; pool_tree=default}' --ignore-existing",
 		"yt clickhouse ctl create ch_public || true",
 		"yt clickhouse ctl set-option --alias ch_public pool chyt",


### PR DESCRIPTION
This job fails on our cluster and it is hard to debug it without debugging information
```
++ yt clickhouse ctl create ch_public
usage: yt clickhouse ctl [--address ADDRESS] command ...
yt clickhouse ctl: error: failed to fetch available commands from controller service
Bad response from controller service

***** Details:
Bad response from controller service    
    origin          ytsaurus-chyt-chyt-init-job-ch-public-77s2b on 2024-03-05T13:27:13.095368Z    
    status_code     404    
    response_body   b'Not Found\n'
```

strawberry_controller logs show that no request arrived at that time. We suspect incorrect endpoint, but we need debug logs for it