### PR TITLE
Refactoring: return structs instead of interfaces

### DIFF
--- a/pkg/components/controller_agent.go
+++ b/pkg/components/controller_agent.go
@@ -11,13 +11,13 @@ import (
 	"github.com/ytsaurus/yt-k8s-operator/pkg/ytconfig"
 )
 
-type controllerAgent struct {
+type ControllerAgent struct {
 	localServerComponent
 	cfgen  *ytconfig.Generator
 	master Component
 }
 
-func NewControllerAgent(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus, master Component) Component {
+func NewControllerAgent(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus, master Component) *ControllerAgent {
 	resource := ytsaurus.GetResource()
 	l := labeller.Labeller{
 		ObjectMeta:     &resource.ObjectMeta,
@@ -38,22 +38,22 @@ func NewControllerAgent(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus, 
 		cfgen.GetControllerAgentConfig,
 	)
 
-	return &controllerAgent{
+	return &ControllerAgent{
 		localServerComponent: newLocalServerComponent(&l, ytsaurus, srv),
 		cfgen:                cfgen,
 		master:               master,
 	}
 }
 
-func (ca *controllerAgent) IsUpdatable() bool {
+func (ca *ControllerAgent) IsUpdatable() bool {
 	return true
 }
 
-func (ca *controllerAgent) Fetch(ctx context.Context) error {
+func (ca *ControllerAgent) Fetch(ctx context.Context) error {
 	return resources.Fetch(ctx, ca.server)
 }
 
-func (ca *controllerAgent) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
+func (ca *ControllerAgent) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(ca.ytsaurus.GetClusterState()) && ca.server.needUpdate() {
@@ -84,7 +84,7 @@ func (ca *controllerAgent) doSync(ctx context.Context, dry bool) (ComponentStatu
 	return SimpleStatus(SyncStatusReady), err
 }
 
-func (ca *controllerAgent) Status(ctx context.Context) ComponentStatus {
+func (ca *ControllerAgent) Status(ctx context.Context) ComponentStatus {
 	status, err := ca.doSync(ctx, true)
 	if err != nil {
 		panic(err)
@@ -93,7 +93,7 @@ func (ca *controllerAgent) Status(ctx context.Context) ComponentStatus {
 	return status
 }
 
-func (ca *controllerAgent) Sync(ctx context.Context) error {
+func (ca *ControllerAgent) Sync(ctx context.Context) error {
 	_, err := ca.doSync(ctx, false)
 	return err
 }

--- a/pkg/components/data_node.go
+++ b/pkg/components/data_node.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ytsaurus/yt-k8s-operator/pkg/ytconfig"
 )
 
-type dataNode struct {
+type DataNode struct {
 	localServerComponent
 	cfgen  *ytconfig.NodeGenerator
 	master Component
@@ -22,7 +22,7 @@ func NewDataNode(
 	ytsaurus *apiproxy.Ytsaurus,
 	master Component,
 	spec ytv1.DataNodesSpec,
-) Component {
+) *DataNode {
 	resource := ytsaurus.GetResource()
 	l := labeller.Labeller{
 		ObjectMeta:     &resource.ObjectMeta,
@@ -45,22 +45,22 @@ func NewDataNode(
 		},
 	)
 
-	return &dataNode{
+	return &DataNode{
 		localServerComponent: newLocalServerComponent(&l, ytsaurus, srv),
 		cfgen:                cfgen,
 		master:               master,
 	}
 }
 
-func (n *dataNode) IsUpdatable() bool {
+func (n *DataNode) IsUpdatable() bool {
 	return true
 }
 
-func (n *dataNode) Fetch(ctx context.Context) error {
+func (n *DataNode) Fetch(ctx context.Context) error {
 	return resources.Fetch(ctx, n.server)
 }
 
-func (n *dataNode) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
+func (n *DataNode) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(n.ytsaurus.GetClusterState()) && n.server.needUpdate() {
@@ -91,7 +91,7 @@ func (n *dataNode) doSync(ctx context.Context, dry bool) (ComponentStatus, error
 	return SimpleStatus(SyncStatusReady), err
 }
 
-func (n *dataNode) Status(ctx context.Context) ComponentStatus {
+func (n *DataNode) Status(ctx context.Context) ComponentStatus {
 	status, err := n.doSync(ctx, true)
 	if err != nil {
 		panic(err)
@@ -100,7 +100,7 @@ func (n *dataNode) Status(ctx context.Context) ComponentStatus {
 	return status
 }
 
-func (n *dataNode) Sync(ctx context.Context) error {
+func (n *DataNode) Sync(ctx context.Context) error {
 	_, err := n.doSync(ctx, false)
 	return err
 }

--- a/pkg/components/discovery.go
+++ b/pkg/components/discovery.go
@@ -11,12 +11,12 @@ import (
 	"github.com/ytsaurus/yt-k8s-operator/pkg/ytconfig"
 )
 
-type discovery struct {
+type Discovery struct {
 	localServerComponent
 	cfgen *ytconfig.Generator
 }
 
-func NewDiscovery(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus) Component {
+func NewDiscovery(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus) *Discovery {
 	resource := ytsaurus.GetResource()
 	l := labeller.Labeller{
 		ObjectMeta:     &resource.ObjectMeta,
@@ -37,21 +37,21 @@ func NewDiscovery(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus) Compon
 		cfgen.GetDiscoveryConfig,
 	)
 
-	return &discovery{
+	return &Discovery{
 		localServerComponent: newLocalServerComponent(&l, ytsaurus, srv),
 		cfgen:                cfgen,
 	}
 }
 
-func (d *discovery) IsUpdatable() bool {
+func (d *Discovery) IsUpdatable() bool {
 	return true
 }
 
-func (d *discovery) Fetch(ctx context.Context) error {
+func (d *Discovery) Fetch(ctx context.Context) error {
 	return resources.Fetch(ctx, d.server)
 }
 
-func (d *discovery) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
+func (d *Discovery) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(d.ytsaurus.GetClusterState()) && d.server.needUpdate() {
@@ -78,7 +78,7 @@ func (d *discovery) doSync(ctx context.Context, dry bool) (ComponentStatus, erro
 	return SimpleStatus(SyncStatusReady), err
 }
 
-func (d *discovery) Status(ctx context.Context) ComponentStatus {
+func (d *Discovery) Status(ctx context.Context) ComponentStatus {
 	status, err := d.doSync(ctx, true)
 	if err != nil {
 		panic(err)
@@ -87,7 +87,7 @@ func (d *discovery) Status(ctx context.Context) ComponentStatus {
 	return status
 }
 
-func (d *discovery) Sync(ctx context.Context) error {
+func (d *Discovery) Sync(ctx context.Context) error {
 	_, err := d.doSync(ctx, false)
 	return err
 }

--- a/pkg/components/httpproxy.go
+++ b/pkg/components/httpproxy.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ytsaurus/yt-k8s-operator/pkg/ytconfig"
 )
 
-type httpProxy struct {
+type HttpProxy struct {
 	localServerComponent
 	cfgen *ytconfig.Generator
 
@@ -32,7 +32,7 @@ func NewHTTPProxy(
 	cfgen *ytconfig.Generator,
 	ytsaurus *apiproxy.Ytsaurus,
 	masterReconciler Component,
-	spec ytv1.HTTPProxiesSpec) Component {
+	spec ytv1.HTTPProxiesSpec) *HttpProxy {
 
 	resource := ytsaurus.GetResource()
 	l := labeller.Labeller{
@@ -73,7 +73,7 @@ func NewHTTPProxy(
 	balancingService.SetHttpNodePort(spec.HttpNodePort)
 	balancingService.SetHttpsNodePort(spec.HttpsNodePort)
 
-	return &httpProxy{
+	return &HttpProxy{
 		localServerComponent: newLocalServerComponent(&l, ytsaurus, srv),
 		cfgen:                cfgen,
 		master:               masterReconciler,
@@ -84,18 +84,18 @@ func NewHTTPProxy(
 	}
 }
 
-func (hp *httpProxy) IsUpdatable() bool {
+func (hp *HttpProxy) IsUpdatable() bool {
 	return true
 }
 
-func (hp *httpProxy) Fetch(ctx context.Context) error {
+func (hp *HttpProxy) Fetch(ctx context.Context) error {
 	return resources.Fetch(ctx,
 		hp.server,
 		hp.balancingService,
 	)
 }
 
-func (hp *httpProxy) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
+func (hp *HttpProxy) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(hp.ytsaurus.GetClusterState()) && hp.server.needUpdate() {
@@ -140,7 +140,7 @@ func (hp *httpProxy) doSync(ctx context.Context, dry bool) (ComponentStatus, err
 	return SimpleStatus(SyncStatusReady), err
 }
 
-func (hp *httpProxy) Status(ctx context.Context) ComponentStatus {
+func (hp *HttpProxy) Status(ctx context.Context) ComponentStatus {
 	status, err := hp.doSync(ctx, true)
 	if err != nil {
 		panic(err)
@@ -149,7 +149,7 @@ func (hp *httpProxy) Status(ctx context.Context) ComponentStatus {
 	return status
 }
 
-func (hp *httpProxy) Sync(ctx context.Context) error {
+func (hp *HttpProxy) Sync(ctx context.Context) error {
 	_, err := hp.doSync(ctx, false)
 	return err
 }

--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -3,8 +3,9 @@ package components
 import (
 	"context"
 	"fmt"
-	"go.ytsaurus.tech/yt/go/yt"
 	"strings"
+
+	"go.ytsaurus.tech/yt/go/yt"
 
 	"go.ytsaurus.tech/library/go/ptr"
 	"go.ytsaurus.tech/yt/go/yson"
@@ -26,7 +27,7 @@ const (
 	defaultHostAddressLabel = "kubernetes.io/hostname"
 )
 
-type master struct {
+type Master struct {
 	localServerComponent
 	cfgen *ytconfig.Generator
 
@@ -35,7 +36,7 @@ type master struct {
 	adminCredentials corev1.Secret
 }
 
-func NewMaster(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus) Component {
+func NewMaster(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus) *Master {
 	resource := ytsaurus.GetResource()
 	l := labeller.Labeller{
 		ObjectMeta:     &resource.ObjectMeta,
@@ -78,7 +79,7 @@ func NewMaster(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus) Component
 		cfgen.GetNativeClientConfig,
 	)
 
-	return &master{
+	return &Master{
 		localServerComponent: newLocalServerComponent(&l, ytsaurus, srv),
 		cfgen:                cfgen,
 		initJob:              initJob,
@@ -86,11 +87,11 @@ func NewMaster(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus) Component
 	}
 }
 
-func (m *master) IsUpdatable() bool {
+func (m *Master) IsUpdatable() bool {
 	return true
 }
 
-func (m *master) Fetch(ctx context.Context) error {
+func (m *Master) Fetch(ctx context.Context) error {
 	if m.ytsaurus.GetResource().Spec.AdminCredentials != nil {
 		err := m.ytsaurus.APIProxy().FetchObject(
 			ctx,
@@ -108,7 +109,7 @@ func (m *master) Fetch(ctx context.Context) error {
 	)
 }
 
-func (m *master) initAdminUser() string {
+func (m *Master) initAdminUser() string {
 	adminLogin, adminPassword := consts.DefaultAdminLogin, consts.DefaultAdminPassword
 	adminToken := consts.DefaultAdminPassword
 
@@ -136,7 +137,7 @@ type Medium struct {
 	Name string `yson:"name"`
 }
 
-func (m *master) getExtraMedia() []Medium {
+func (m *Master) getExtraMedia() []Medium {
 	mediaMap := make(map[string]Medium)
 
 	for _, d := range m.ytsaurus.GetResource().Spec.DataNodes {
@@ -158,7 +159,7 @@ func (m *master) getExtraMedia() []Medium {
 	return mediaSlice
 }
 
-func (m *master) initMedia() string {
+func (m *Master) initMedia() string {
 	var commands []string
 	for _, medium := range m.getExtraMedia() {
 		attr, err := yson.MarshalFormat(medium, yson.FormatText)
@@ -170,14 +171,14 @@ func (m *master) initMedia() string {
 	return strings.Join(commands, "\n")
 }
 
-func (m *master) initGroups() string {
+func (m *Master) initGroups() string {
 	commands := []string{
 		"/usr/bin/yt create group --attr '{name=admins}' --ignore-existing",
 	}
 	return strings.Join(commands, "\n")
 }
 
-func (m *master) initSchemaACLs() string {
+func (m *Master) initSchemaACLs() string {
 	userReadACE := yt.ACE{
 		Action:      "allow",
 		Subjects:    []string{"users"},
@@ -241,7 +242,7 @@ func (m *master) initSchemaACLs() string {
 	return strings.Join(commands, "\n")
 }
 
-func (m *master) createInitScript() string {
+func (m *Master) createInitScript() string {
 	clusterConnection, err := m.cfgen.GetClusterConnection()
 	if err != nil {
 		panic(err)
@@ -266,7 +267,7 @@ func (m *master) createInitScript() string {
 	return strings.Join(script, "\n")
 }
 
-func (m *master) createExitReadOnlyScript() string {
+func (m *Master) createExitReadOnlyScript() string {
 	script := []string{
 		initJobWithNativeDriverPrologue(),
 		"export YT_LOG_LEVEL=DEBUG",
@@ -278,7 +279,7 @@ func (m *master) createExitReadOnlyScript() string {
 	return strings.Join(script, "\n")
 }
 
-func (m *master) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
+func (m *Master) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(m.ytsaurus.GetClusterState()) && m.server.needUpdate() {
@@ -313,7 +314,7 @@ func (m *master) doSync(ctx context.Context, dry bool) (ComponentStatus, error) 
 	return m.initJob.Sync(ctx, dry)
 }
 
-func (m *master) Status(ctx context.Context) ComponentStatus {
+func (m *Master) Status(ctx context.Context) ComponentStatus {
 	status, err := m.doSync(ctx, true)
 	if err != nil {
 		panic(err)
@@ -322,18 +323,18 @@ func (m *master) Status(ctx context.Context) ComponentStatus {
 	return status
 }
 
-func (m *master) Sync(ctx context.Context) error {
+func (m *Master) Sync(ctx context.Context) error {
 	_, err := m.doSync(ctx, false)
 	return err
 }
 
-func (m *master) doServerSync(ctx context.Context) error {
+func (m *Master) doServerSync(ctx context.Context) error {
 	statefulSet := m.server.buildStatefulSet()
 	m.addAffinity(statefulSet)
 	return m.server.Sync(ctx)
 }
 
-func (m *master) addAffinity(statefulSet *appsv1.StatefulSet) {
+func (m *Master) addAffinity(statefulSet *appsv1.StatefulSet) {
 	primaryMastersSpec := m.ytsaurus.GetResource().Spec.PrimaryMasters
 	if len(primaryMastersSpec.HostAddresses) == 0 {
 		return
@@ -369,7 +370,7 @@ func (m *master) addAffinity(statefulSet *appsv1.StatefulSet) {
 	statefulSet.Spec.Template.Spec.Affinity = affinity
 }
 
-func (m *master) getHostAddressLabel() string {
+func (m *Master) getHostAddressLabel() string {
 	primaryMastersSpec := m.ytsaurus.GetResource().Spec.PrimaryMasters
 	if primaryMastersSpec.HostAddressLabel != "" {
 		return primaryMastersSpec.HostAddressLabel
@@ -377,7 +378,7 @@ func (m *master) getHostAddressLabel() string {
 	return defaultHostAddressLabel
 }
 
-func (m *master) exitReadOnly(ctx context.Context, dry bool) (*ComponentStatus, error) {
+func (m *Master) exitReadOnly(ctx context.Context, dry bool) (*ComponentStatus, error) {
 	if !m.ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionMasterExitReadOnlyPrepared) {
 		if !m.exitReadOnlyJob.isRestartPrepared() {
 			if err := m.exitReadOnlyJob.prepareRestart(ctx, dry); err != nil {
@@ -411,7 +412,7 @@ func (m *master) exitReadOnly(ctx context.Context, dry bool) (*ComponentStatus, 
 	return ptr.T(SimpleStatus(SyncStatusUpdating)), nil
 }
 
-func (m *master) setMasterReadOnlyExitPrepared(ctx context.Context, status metav1.ConditionStatus) {
+func (m *Master) setMasterReadOnlyExitPrepared(ctx context.Context, status metav1.ConditionStatus) {
 	m.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
 		Type:    consts.ConditionMasterExitReadOnlyPrepared,
 		Status:  status,

--- a/pkg/components/rpcproxy.go
+++ b/pkg/components/rpcproxy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ytsaurus/yt-k8s-operator/pkg/ytconfig"
 )
 
-type rpcProxy struct {
+type RpcProxy struct {
 	localServerComponent
 	cfgen *ytconfig.Generator
 
@@ -28,7 +28,7 @@ func NewRPCProxy(
 	cfgen *ytconfig.Generator,
 	ytsaurus *apiproxy.Ytsaurus,
 	masterReconciler Component,
-	spec ytv1.RPCProxiesSpec) Component {
+	spec ytv1.RPCProxiesSpec) *RpcProxy {
 	resource := ytsaurus.GetResource()
 	l := labeller.Labeller{
 		ObjectMeta:     &resource.ObjectMeta,
@@ -69,7 +69,7 @@ func NewRPCProxy(
 			consts.RPCSecretMountPoint)
 	}
 
-	return &rpcProxy{
+	return &RpcProxy{
 		localServerComponent: newLocalServerComponent(&l, ytsaurus, srv),
 		cfgen:                cfgen,
 		master:               masterReconciler,
@@ -79,11 +79,11 @@ func NewRPCProxy(
 	}
 }
 
-func (rp *rpcProxy) IsUpdatable() bool {
+func (rp *RpcProxy) IsUpdatable() bool {
 	return true
 }
 
-func (rp *rpcProxy) Fetch(ctx context.Context) error {
+func (rp *RpcProxy) Fetch(ctx context.Context) error {
 	fetchable := []resources.Fetchable{
 		rp.server,
 	}
@@ -93,7 +93,7 @@ func (rp *rpcProxy) Fetch(ctx context.Context) error {
 	return resources.Fetch(ctx, fetchable...)
 }
 
-func (rp *rpcProxy) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
+func (rp *RpcProxy) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(rp.ytsaurus.GetClusterState()) && rp.server.needUpdate() {
@@ -138,7 +138,7 @@ func (rp *rpcProxy) doSync(ctx context.Context, dry bool) (ComponentStatus, erro
 	return SimpleStatus(SyncStatusReady), err
 }
 
-func (rp *rpcProxy) Status(ctx context.Context) ComponentStatus {
+func (rp *RpcProxy) Status(ctx context.Context) ComponentStatus {
 	status, err := rp.doSync(ctx, true)
 	if err != nil {
 		panic(err)
@@ -147,7 +147,7 @@ func (rp *rpcProxy) Status(ctx context.Context) ComponentStatus {
 	return status
 }
 
-func (rp *rpcProxy) Sync(ctx context.Context) error {
+func (rp *RpcProxy) Sync(ctx context.Context) error {
 	_, err := rp.doSync(ctx, false)
 	return err
 }

--- a/pkg/components/tablet_node_test.go
+++ b/pkg/components/tablet_node_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Tablet node test", func() {
 
 			ytsaurusClient.SetStatus(SimpleStatus(SyncStatusPending))
 
-			tabletNode := NewTabletNode(cfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], true).(*tabletNode)
+			tabletNode := NewTabletNode(cfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], true)
 			tabletNode.server = NewFakeServer()
 			Expect(tabletNode.Status(context.Background()).SyncStatus).Should(Equal(SyncStatusBlocked))
 
@@ -185,7 +185,7 @@ var _ = Describe("Tablet node test", func() {
 			ytsaurus := apiproxy.NewYtsaurus(ytsaurusSpec, client, record.NewFakeRecorder(1), scheme)
 
 			ytsaurusClient := NewFakeYtsaurusClient(mockYtClient)
-			tabletNode := NewTabletNode(cfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], true).(*tabletNode)
+			tabletNode := NewTabletNode(cfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], true)
 			fakeServer := NewFakeServer()
 			fakeServer.podsReady = false
 			tabletNode.server = fakeServer
@@ -322,7 +322,7 @@ var _ = Describe("Tablet node test", func() {
 			)
 
 			nodeCfgen := ytconfig.NewLocalNodeGenerator(ytsaurusSpec, "cluster_domain")
-			tabletNode := NewTabletNode(nodeCfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], true).(*tabletNode)
+			tabletNode := NewTabletNode(nodeCfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], true)
 			tabletNode.server = NewFakeServer()
 
 			// Failed to check if there is //sys/tablet_cell_bundles/sys.
@@ -403,7 +403,7 @@ var _ = Describe("Tablet node test", func() {
 			}
 
 			nodeCfgen := ytconfig.NewLocalNodeGenerator(ytsaurusSpec, "cluster_domain")
-			tabletNode := NewTabletNode(nodeCfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], true).(*tabletNode)
+			tabletNode := NewTabletNode(nodeCfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], true)
 			tabletNode.server = NewFakeServer()
 			err := tabletNode.Sync(context.Background())
 			Expect(err).Should(Succeed())
@@ -417,7 +417,7 @@ var _ = Describe("Tablet node test", func() {
 			ytsaurusClient := NewFakeYtsaurusClient(mockYtClient)
 
 			cfgen := ytconfig.NewLocalNodeGenerator(ytsaurusSpec, "cluster_domain")
-			tabletNode := NewTabletNode(cfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], false).(*tabletNode)
+			tabletNode := NewTabletNode(cfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], false)
 			tabletNode.server = NewFakeServer()
 			err := tabletNode.Sync(context.Background())
 			Expect(err).Should(Succeed())

--- a/pkg/components/tcpproxy.go
+++ b/pkg/components/tcpproxy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ytsaurus/yt-k8s-operator/pkg/ytconfig"
 )
 
-type tcpProxy struct {
+type TcpProxy struct {
 	localServerComponent
 	cfgen *ytconfig.Generator
 
@@ -27,7 +27,7 @@ func NewTCPProxy(
 	cfgen *ytconfig.Generator,
 	ytsaurus *apiproxy.Ytsaurus,
 	masterReconciler Component,
-	spec ytv1.TCPProxiesSpec) Component {
+	spec ytv1.TCPProxiesSpec) *TcpProxy {
 	resource := ytsaurus.GetResource()
 	l := labeller.Labeller{
 		ObjectMeta:     &resource.ObjectMeta,
@@ -61,7 +61,7 @@ func NewTCPProxy(
 			ytsaurus.APIProxy())
 	}
 
-	return &tcpProxy{
+	return &TcpProxy{
 		localServerComponent: newLocalServerComponent(&l, ytsaurus, srv),
 		cfgen:                cfgen,
 		master:               masterReconciler,
@@ -70,11 +70,11 @@ func NewTCPProxy(
 	}
 }
 
-func (tp *tcpProxy) IsUpdatable() bool {
+func (tp *TcpProxy) IsUpdatable() bool {
 	return true
 }
 
-func (tp *tcpProxy) Fetch(ctx context.Context) error {
+func (tp *TcpProxy) Fetch(ctx context.Context) error {
 	fetchable := []resources.Fetchable{
 		tp.server,
 	}
@@ -84,7 +84,7 @@ func (tp *tcpProxy) Fetch(ctx context.Context) error {
 	return resources.Fetch(ctx, fetchable...)
 }
 
-func (tp *tcpProxy) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
+func (tp *TcpProxy) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(tp.ytsaurus.GetClusterState()) && tp.server.needUpdate() {
@@ -123,7 +123,7 @@ func (tp *tcpProxy) doSync(ctx context.Context, dry bool) (ComponentStatus, erro
 	return SimpleStatus(SyncStatusReady), err
 }
 
-func (tp *tcpProxy) Status(ctx context.Context) ComponentStatus {
+func (tp *TcpProxy) Status(ctx context.Context) ComponentStatus {
 	status, err := tp.doSync(ctx, true)
 	if err != nil {
 		panic(err)
@@ -132,7 +132,7 @@ func (tp *tcpProxy) Status(ctx context.Context) ComponentStatus {
 	return status
 }
 
-func (tp *tcpProxy) Sync(ctx context.Context) error {
+func (tp *TcpProxy) Sync(ctx context.Context) error {
 	_, err := tp.doSync(ctx, false)
 	return err
 }

--- a/pkg/components/ui.go
+++ b/pkg/components/ui.go
@@ -29,7 +29,7 @@ type UI struct {
 const UIClustersConfigFileName = "clusters-config.json"
 const UICustomConfigFileName = "common.js"
 
-func NewUI(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus, master Component) Component {
+func NewUI(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus, master Component) *UI {
 	resource := ytsaurus.GetResource()
 	l := labeller.Labeller{
 		ObjectMeta:     &resource.ObjectMeta,


### PR DESCRIPTION
Best practice is to return public struct instead of interfaces in New* methods. 
That way code become more loosely coupled and returned structs can implement multiple interfaces at the same time without casting.