### PR TITLE
Refactor: remove server interface

### DIFF
--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -79,7 +79,7 @@ type localComponent struct {
 // and use server. Almost all components are based on this struct.
 type localServerComponent struct {
 	localComponent
-	server server
+	server *server
 }
 
 func newLocalComponent(
@@ -108,7 +108,7 @@ func (c *localComponent) SetReadyCondition(status ComponentStatus) {
 func newLocalServerComponent(
 	labeller *labeller.Labeller,
 	ytsaurus *apiproxy.Ytsaurus,
-	server server,
+	server *server,
 ) localServerComponent {
 	return localServerComponent{
 		localComponent: localComponent{
@@ -125,7 +125,7 @@ func (c *localServerComponent) NeedSync() bool {
 	return LocalServerNeedSync(c.server, c.ytsaurus)
 }
 
-func LocalServerNeedSync(srv server, ytsaurus *apiproxy.Ytsaurus) bool {
+func LocalServerNeedSync(srv *server, ytsaurus *apiproxy.Ytsaurus) bool {
 	return (srv.configNeedsReload() && ytsaurus.IsUpdating()) ||
 		srv.needBuild()
 }

--- a/pkg/components/exec_node_base.go
+++ b/pkg/components/exec_node_base.go
@@ -13,7 +13,7 @@ import (
 )
 
 type baseExecNode struct {
-	server     server
+	server     *server
 	cfgen      *ytconfig.NodeGenerator
 	sidecars   []string
 	privileged bool

--- a/pkg/components/helpers.go
+++ b/pkg/components/helpers.go
@@ -118,7 +118,7 @@ func handleUpdatingClusterState(
 	ytsaurus *apiproxy.Ytsaurus,
 	cmp Component,
 	cmpBase *localComponent,
-	server server,
+	server *server,
 	dry bool,
 ) (*ComponentStatus, error) {
 	var err error


### PR DESCRIPTION
Simple struct is enough until we want to mock it or pass it somewhere and incapsulate implementation that way.
Embedding interface field in all components makes our code inflexible.