### PR TITLE
Add ACO queries/everyone for convenience

### DIFF
--- a/controllers/ytsaurus_controller_test.go
+++ b/controllers/ytsaurus_controller_test.go
@@ -372,7 +372,7 @@ var _ = Describe("Basic test for Ytsaurus controller", func() {
 			runImpossibleUpdateAndRollback(ytsaurus, ytClient)
 		})
 
-		It("Should run with query tracker and check that access control object namespace 'queries' and object 'nobody' exists", func() {
+		It("Should run with query tracker and check that access control object namespace 'queries' and objects 'nobody' and 'everyone' exist", func() {
 			By("Creating a Ytsaurus resource")
 			ctx := context.Background()
 
@@ -399,6 +399,16 @@ var _ = Describe("Basic test for Ytsaurus controller", func() {
 
 			By("Check that access control object 'nobody' in namespace 'queries' exists")
 			Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries/nobody"), nil)).Should(Equal(true))
+
+			By("Check that access control object 'everyone' in namespace 'queries' exists")
+			Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries/everyone"), nil)).Should(Equal(true))
+
+			By("Check that access control object 'everyone' in namespace 'queries' allows everyone")
+			everyonePrincipalAcl := []map[string]interface{}{}
+			Expect(ytClient.GetNode(ctx, ypath.Path("//sys/access_control_object_namespaces/queries/everyone/@principal_acl"), &everyonePrincipalAcl, nil)).Should(Succeed())
+			Expect(everyonePrincipalAcl[0]).Should(HaveKeyWithValue("action", "allow"))
+			Expect(everyonePrincipalAcl[0]).Should(HaveKeyWithValue("subjects", ContainElement("everyone")))
+			Expect(everyonePrincipalAcl[0]).Should(HaveKeyWithValue("permissions", ContainElement("use")))
 		})
 	})
 

--- a/pkg/components/query_tracker.go
+++ b/pkg/components/query_tracker.go
@@ -315,6 +315,27 @@ func (qt *QueryTracker) init(ctx context.Context, ytClient yt.Client) (err error
 		logger.Error(err, "Creating access control object 'nobody' in namespace 'queries' failed")
 		return
 	}
+
+	_, err = ytClient.CreateObject(
+		ctx,
+		yt.NodeAccessControlObject,
+		&yt.CreateObjectOptions{
+			Attributes: map[string]interface{}{
+				"name":      "everyone",
+				"namespace": "queries",
+				"principal_acl": []interface{}{map[string]interface{}{
+					"action":      "allow",
+					"subjects":    []string{"everyone"},
+					"permissions": []string{"use"},
+				}},
+			},
+			IgnoreExisting: true,
+		},
+	)
+	if err != nil {
+		logger.Error(err, "Creating access control object 'everyone' in namespace 'queries' failed")
+		return
+	}
 	return
 }
 


### PR DESCRIPTION
Main big issue: https://github.com/ytsaurus/ytsaurus/issues/175

Currently, only `queries/nobody` ACO is created since it is required for QT ACL to work

But, most likely, users will need a convenient `queries/everyone` ACO to quickly select and share their query. Adding it here to save work for cluster administrators or users