### PR TITLE
Tune tablet changelog/snapshot initial replication factor according to data node count

### DIFF
--- a/pkg/components/tablet_node.go
+++ b/pkg/components/tablet_node.go
@@ -125,7 +125,7 @@ func (tn *TabletNode) doSync(ctx context.Context, dry bool) (ComponentStatus, er
 		if tn.doInitialization {
 			if exists, err := ytClient.NodeExists(ctx, ypath.Path(fmt.Sprintf("//sys/tablet_cell_bundles/%s", SysBundle)), nil); err == nil {
 				if !exists {
-					options := map[string]string{
+					options := map[string]any{
 						"changelog_account": "sys",
 						"snapshot_account":  "sys",
 					}
@@ -138,6 +138,13 @@ func (tn *TabletNode) doSync(ctx context.Context, dry bool) (ComponentStatus, er
 						if bootstrap.SnapshotPrimaryMedium != nil {
 							options["snapshot_primary_medium"] = *bootstrap.SnapshotPrimaryMedium
 						}
+					}
+
+					if tn.cfgen.GetMaxReplicationFactor() < 3 {
+						options["changelog_replication_factor"] = 1
+						options["changelog_read_quorum"] = 1
+						options["changelog_write_quorum"] = 1
+						options["snapshot_replication_factor"] = 1
 					}
 
 					_, err = ytClient.CreateObject(ctx, yt.NodeTabletCellBundle, &yt.CreateObjectOptions{

--- a/pkg/components/tablet_node_test.go
+++ b/pkg/components/tablet_node_test.go
@@ -395,9 +395,13 @@ var _ = Describe("Tablet node test", func() {
 					gomock.Eq(&yt.CreateObjectOptions{
 						Attributes: map[string]interface{}{
 							"name": "sys",
-							"options": map[string]string{
-								"changelog_account": "sys",
-								"snapshot_account":  "sys",
+							"options": map[string]any{
+								"changelog_account":            "sys",
+								"snapshot_account":             "sys",
+								"changelog_replication_factor": 1,
+								"changelog_read_quorum":        1,
+								"changelog_write_quorum":       1,
+								"snapshot_replication_factor":  1,
 							},
 						}})).
 				Return(yt.NodeID(guid.New()), nil)

--- a/pkg/ytconfig/base_generator.go
+++ b/pkg/ytconfig/base_generator.go
@@ -14,6 +14,7 @@ type BaseGenerator struct {
 	masterConnectionSpec   ytv1.MasterConnectionSpec
 	masterInstanceCount    int32
 	discoveryInstanceCount int32
+	dataNodesInstanceCount int32
 	masterCachesSpec       *ytv1.MasterCachesSpec
 }
 
@@ -37,6 +38,11 @@ func NewLocalBaseGenerator(
 	ytsaurus *ytv1.Ytsaurus,
 	clusterDomain string,
 ) *BaseGenerator {
+	var dataNodesInstanceCount int32
+	for _, dataNodes := range ytsaurus.Spec.DataNodes {
+		dataNodesInstanceCount += dataNodes.InstanceCount
+	}
+
 	return &BaseGenerator{
 		key: types.NamespacedName{
 			Namespace: ytsaurus.Namespace,
@@ -48,5 +54,10 @@ func NewLocalBaseGenerator(
 		masterInstanceCount:    ytsaurus.Spec.PrimaryMasters.InstanceCount,
 		discoveryInstanceCount: ytsaurus.Spec.Discovery.InstanceCount,
 		masterCachesSpec:       ytsaurus.Spec.MasterCaches,
+		dataNodesInstanceCount: dataNodesInstanceCount,
 	}
+}
+
+func (g *BaseGenerator) GetMaxReplicationFactor() int32 {
+	return g.dataNodesInstanceCount
 }

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -299,7 +299,7 @@ func (g *Generator) getMasterConfigImpl(spec *ytv1.MastersSpec) (MasterServer, e
 	g.fillCommonService(&c.CommonServer, &spec.InstanceSpec)
 	g.fillBusServer(&c.CommonServer, spec.NativeTransport)
 	g.fillPrimaryMaster(&c.PrimaryMaster)
-	configureMasterServerCypressManager(g.ytsaurus.Spec, &c.CypressManager)
+	configureMasterServerCypressManager(g.GetMaxReplicationFactor(), &c.CypressManager)
 
 	// COMPAT(l0kix2): remove that after we drop support for specifying host network without master host addresses.
 	if g.ytsaurus.Spec.HostNetwork && len(spec.HostAddresses) == 0 {

--- a/pkg/ytconfig/master.go
+++ b/pkg/ytconfig/master.go
@@ -80,32 +80,27 @@ func getMasterServerCarcass(spec *ytv1.MastersSpec) (MasterServer, error) {
 	return c, nil
 }
 
-func configureMasterServerCypressManager(spec ytv1.YtsaurusSpec, c *CypressManager) {
-	instanceCount := int32(0)
-	for _, dataNodes := range spec.DataNodes {
-		instanceCount += dataNodes.InstanceCount
-	}
-
+func configureMasterServerCypressManager(maxReplicationFactor int32, c *CypressManager) {
 	switch {
-	case instanceCount <= 1:
+	case maxReplicationFactor <= 1:
 		c.DefaultJournalReadQuorum = 1
 		c.DefaultJournalWriteQuorum = 1
 		c.DefaultTableReplicationFactor = 1
 		c.DefaultFileReplicationFactor = 1
 		c.DefaultJournalReplicationFactor = 1
-	case instanceCount == 2:
+	case maxReplicationFactor == 2:
 		c.DefaultJournalReadQuorum = 2
 		c.DefaultJournalWriteQuorum = 2
 		c.DefaultTableReplicationFactor = 2
 		c.DefaultFileReplicationFactor = 2
 		c.DefaultJournalReplicationFactor = 2
-	case instanceCount >= 3 && instanceCount < 5:
+	case maxReplicationFactor >= 3 && maxReplicationFactor < 5:
 		c.DefaultJournalReadQuorum = 2
 		c.DefaultJournalWriteQuorum = 2
 		c.DefaultTableReplicationFactor = 3
 		c.DefaultFileReplicationFactor = 3
 		c.DefaultJournalReplicationFactor = 3
-	case instanceCount >= 5:
+	case maxReplicationFactor >= 5:
 		c.DefaultJournalReadQuorum = 3
 		c.DefaultJournalWriteQuorum = 3
 		c.DefaultTableReplicationFactor = 3


### PR DESCRIPTION
Use 1 replica for less than 3 data nodes, and default 3 replicas otherwise.

Link: https://github.com/ytsaurus/ytsaurus/blob/b9b7e0918d2141a5c041b217bcd6cc1b7ff7e8d9/yt/yt/tests/library/yt_env_setup.py#L1684