### PR TITLE
Fallback to default RPC Proxy auth behaviour

### DIFF
--- a/api/v1/test_helpers.go
+++ b/api/v1/test_helpers.go
@@ -194,6 +194,13 @@ func WithQueryTracker(ytsaurus *Ytsaurus) *Ytsaurus {
 	return ytsaurus
 }
 
+func WithRPCProxies(ytsaurus *Ytsaurus) *Ytsaurus {
+	ytsaurus.Spec.RPCProxies = []RPCProxiesSpec{
+		createRPCProxiesSpec(),
+	}
+	return ytsaurus
+}
+
 func createHTTPProxiesSpec() HTTPProxiesSpec {
 	return HTTPProxiesSpec{
 		ServiceType: "NodePort",
@@ -201,6 +208,17 @@ func createHTTPProxiesSpec() HTTPProxiesSpec {
 			InstanceCount: 1,
 		},
 		HttpNodePort: getPortFromEnv("E2E_HTTP_PROXY_INTERNAL_PORT"),
+	}
+}
+
+func createRPCProxiesSpec() RPCProxiesSpec {
+	stype := corev1.ServiceTypeNodePort
+	return RPCProxiesSpec{
+		ServiceType: &stype,
+		InstanceSpec: InstanceSpec{
+			InstanceCount: 1,
+		},
+		NodePort: getPortFromEnv("E2E_RPC_PROXY_INTERNAL_PORT"),
 	}
 }
 

--- a/pkg/ytconfig/canondata/TestGetRPCProxyWithoutOauthConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetRPCProxyWithoutOauthConfig/test.canondata
@@ -80,5 +80,4 @@
     "cypress_token_authenticator"={
         secure=%true;
     };
-    "require_authentication"=%false;
 }

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"path"
 
-	"go.ytsaurus.tech/yt/go/yson"
 	corev1 "k8s.io/api/core/v1"
 	ptr "k8s.io/utils/pointer"
+
+	"go.ytsaurus.tech/yt/go/yson"
 
 	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/consts"
@@ -384,7 +385,7 @@ func (g *Generator) getRPCProxyConfigImpl(spec *ytv1.RPCProxiesSpec) (RPCProxySe
 			UserInfoErrorField: g.ytsaurus.Spec.OauthService.UserInfo.ErrorField,
 		}
 		c.OauthTokenAuthenticator = &OauthTokenAuthenticator{}
-		c.RequireAuthentication = true
+		c.RequireAuthentication = ptr.Bool(true)
 	}
 
 	return c, nil

--- a/pkg/ytconfig/proxy.go
+++ b/pkg/ytconfig/proxy.go
@@ -82,7 +82,7 @@ type RPCProxyServer struct {
 	CypressTokenAuthenticator CypressTokenAuthenticator `yson:"cypress_token_authenticator"`
 	OauthService              *OauthService             `yson:"oauth_service,omitempty"`
 	OauthTokenAuthenticator   *OauthTokenAuthenticator  `yson:"oauth_token_authenticator,omitempty"`
-	RequireAuthentication     bool                      `yson:"require_authentication"`
+	RequireAuthentication     *bool                     `yson:"require_authentication,omitempty"`
 }
 
 type TCPProxyServer struct {


### PR DESCRIPTION
Fix #207 

By default, RPC Proxies have require_authentication=true, but operator sets value to false (if Oauth is not configured). 
Fixing it by not setting the value (if Oauth is not configured) so fallback on default is expected.