### PR TITLE
Set EnableServiceLinks=false for all pods

### DIFF
--- a/pkg/components/server.go
+++ b/pkg/components/server.go
@@ -261,11 +261,11 @@ func (s *serverImpl) rebuildStatefulSet() *appsv1.StatefulSet {
 	command = append(command, s.instanceSpec.EntrypointWrapper...)
 	command = append(command, s.binaryPath, "--config", path.Join(consts.ConfigMountPoint, fileNames[0]))
 
-	setHostnameAsFQDN := true
 	statefulSet.Spec.Template.Spec = corev1.PodSpec{
-		RuntimeClassName:  s.instanceSpec.RuntimeClassName,
-		ImagePullSecrets:  s.commonSpec.ImagePullSecrets,
-		SetHostnameAsFQDN: &setHostnameAsFQDN,
+		RuntimeClassName:   s.instanceSpec.RuntimeClassName,
+		ImagePullSecrets:   s.commonSpec.ImagePullSecrets,
+		SetHostnameAsFQDN:  ptr.Bool(true),
+		EnableServiceLinks: ptr.Bool(false),
 		Containers: []corev1.Container{
 			{
 				Image:        s.image,


### PR DESCRIPTION
This is legacy feature which contaminates environment variables
with docker-compatible references to all services in namespace.

Link: https://kubernetes.io/docs/tutorials/services/connect-applications-service/#accessing-the-service
Link: https://github.com/kubernetes/kubernetes/issues/121787
