### PR TITLE
Job script updated on restart

### DIFF
--- a/pkg/components/config_helper.go
+++ b/pkg/components/config_helper.go
@@ -10,12 +10,13 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/google/go-cmp/cmp"
+	"go.ytsaurus.tech/yt/go/yson"
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/ytsaurus/yt-k8s-operator/pkg/apiproxy"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/labeller"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/resources"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/ytconfig"
-	"go.ytsaurus.tech/yt/go/yson"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -241,4 +242,19 @@ func (h *ConfigHelper) Fetch(ctx context.Context) error {
 		}
 	}
 	return h.configMap.Fetch(ctx)
+}
+
+func (h *ConfigHelper) RemoveIfExists(ctx context.Context) error {
+	if !resources.Exists(h.configMap) {
+		return nil
+	}
+
+	return h.apiProxy.DeleteObject(
+		ctx,
+		h.configMap.OldObject(),
+	)
+}
+
+func (h *ConfigHelper) Exists() bool {
+	return resources.Exists(h.configMap)
 }

--- a/pkg/components/init_job.go
+++ b/pkg/components/init_job.go
@@ -178,6 +178,15 @@ func (j *InitJob) prepareRestart(ctx context.Context, dry bool) error {
 	if dry {
 		return nil
 	}
+	if resources.Exists(j.configHelper.configMap) {
+		if err := j.apiProxy.DeleteObject(
+			ctx,
+			j.configHelper.configMap.OldObject(),
+		); err != nil {
+			return err
+		}
+	}
+
 	if err := j.removeIfExists(ctx); err != nil {
 		return err
 	}
@@ -191,7 +200,7 @@ func (j *InitJob) prepareRestart(ctx context.Context, dry bool) error {
 }
 
 func (j *InitJob) isRestartPrepared() bool {
-	return !resources.Exists(j.initJob) && j.conditionsManager.IsStatusConditionFalse(j.initCompletedCondition)
+	return !resources.Exists(j.initJob) && !resources.Exists(j.configHelper.configMap) && j.conditionsManager.IsStatusConditionFalse(j.initCompletedCondition)
 }
 
 func (j *InitJob) isRestartCompleted() bool {

--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -5,16 +5,13 @@ import (
 	"fmt"
 	"strings"
 
-	"go.ytsaurus.tech/yt/go/yt"
-
 	"go.ytsaurus.tech/library/go/ptr"
 	"go.ytsaurus.tech/yt/go/yson"
+	"go.ytsaurus.tech/yt/go/yt"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
-
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/ytsaurus/yt-k8s-operator/pkg/apiproxy"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/consts"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/labeller"


### PR DESCRIPTION
Fixes https://github.com/ytsaurus/yt-k8s-operator/issues/187

Deleting configMap with job script on job restart so new versions of operator could change job script.