### PR TITLE
Add option for creating ephemeral cluster

### DIFF
--- a/api/v1/test_helpers.go
+++ b/api/v1/test_helpers.go
@@ -49,8 +49,9 @@ func CreateMinimalYtsaurusResource(namespace string) *Ytsaurus {
 		},
 		Spec: YtsaurusSpec{
 			CommonSpec: CommonSpec{
-				UseShortNames: true,
-				CoreImage:     CoreImageFirst,
+				EphemeralCluster: true,
+				UseShortNames:    true,
+				CoreImage:        CoreImageFirst,
 			},
 			EnableFullUpdate: true,
 			IsManaged:        true,

--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -504,6 +504,11 @@ type CommonSpec struct {
 	//+optional
 	NativeTransport *RPCTransportSpec `json:"nativeTransport,omitempty"`
 
+	// Allow prioritizing performance over data safety. Useful for tests and experiments.
+	//+kubebuilder:default:=false
+	//+optional
+	EphemeralCluster bool `json:"ephemeralCluster,omitempty"`
+
 	//+kubebuilder:default:=false
 	//+optional
 	UseIPv6 bool `json:"useIpv6"`

--- a/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
@@ -662,6 +662,10 @@ spec:
                 items:
                   type: string
                 type: array
+              ephemeralCluster:
+                default: false
+                description: Allow prioritizing performance over data safety.
+                type: boolean
               extraPodAnnotations:
                 additionalProperties:
                   type: string

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -7159,6 +7159,10 @@ spec:
               enableFullUpdate:
                 default: true
                 type: boolean
+              ephemeralCluster:
+                default: false
+                description: Allow prioritizing performance over data safety.
+                type: boolean
               execNodes:
                 items:
                   properties:

--- a/docs/api.md
+++ b/docs/api.md
@@ -231,6 +231,7 @@ _Appears in:_
 | `jobImage` _string_ | Default docker image for user jobs. |  |  |
 | `caBundle` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | Reference to ConfigMap with trusted certificates: "ca.crt". |  |  |
 | `nativeTransport` _[RPCTransportSpec](#rpctransportspec)_ | Common config for native RPC bus transport. |  |  |
+| `ephemeralCluster` _boolean_ | Allow prioritizing performance over data safety. Useful for tests and experiments. | false |  |
 | `useIpv6` _boolean_ |  | false |  |
 | `useIpv4` _boolean_ |  | false |  |
 | `useShortNames` _boolean_ |  | true |  |
@@ -1076,6 +1077,7 @@ _Appears in:_
 | `jobImage` _string_ | Default docker image for user jobs. |  |  |
 | `caBundle` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | Reference to ConfigMap with trusted certificates: "ca.crt". |  |  |
 | `nativeTransport` _[RPCTransportSpec](#rpctransportspec)_ | Common config for native RPC bus transport. |  |  |
+| `ephemeralCluster` _boolean_ | Allow prioritizing performance over data safety. Useful for tests and experiments. | false |  |
 | `useIpv6` _boolean_ |  | false |  |
 | `useIpv4` _boolean_ |  | false |  |
 | `useShortNames` _boolean_ |  | true |  |
@@ -1561,6 +1563,7 @@ _Appears in:_
 | `jobImage` _string_ | Default docker image for user jobs. |  |  |
 | `caBundle` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | Reference to ConfigMap with trusted certificates: "ca.crt". |  |  |
 | `nativeTransport` _[RPCTransportSpec](#rpctransportspec)_ | Common config for native RPC bus transport. |  |  |
+| `ephemeralCluster` _boolean_ | Allow prioritizing performance over data safety. Useful for tests and experiments. | false |  |
 | `useIpv6` _boolean_ |  | false |  |
 | `useIpv4` _boolean_ |  | false |  |
 | `useShortNames` _boolean_ |  | true |  |

--- a/pkg/ytconfig/common.go
+++ b/pkg/ytconfig/common.go
@@ -120,6 +120,10 @@ type RetryingChannel struct {
 	RetryTimeout     yson.Duration `yson:"retry_timeout,omitempty"`
 }
 
+type IOEngine struct {
+	EnableSync *bool `yson:"enable_sync,omitempty"`
+}
+
 func createLogging(spec *ytv1.InstanceSpec, componentName string, defaultLoggerSpecs []ytv1.TextLoggerSpec) Logging {
 	loggingBuilder := newLoggingBuilder(ytv1.FindFirstLocation(spec.Locations, ytv1.LocationTypeLogs), componentName)
 	if spec.Loggers != nil && len(spec.Loggers) > 0 {

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -124,6 +124,15 @@ func (g *Generator) GetQueueAgentAddresses() []string {
 	return names
 }
 
+func (g *BaseGenerator) fillIOEngine(ioEngine **IOEngine) {
+	if g.commonSpec.EphemeralCluster {
+		if *ioEngine == nil {
+			*ioEngine = &IOEngine{}
+		}
+		(*ioEngine).EnableSync = ptr.Bool(false)
+	}
+}
+
 func (g *Generator) fillDriver(c *Driver) {
 	c.TimestampProviders.Addresses = g.getMasterAddresses()
 
@@ -297,6 +306,7 @@ func (g *Generator) getMasterConfigImpl(spec *ytv1.MastersSpec) (MasterServer, e
 	if err != nil {
 		return MasterServer{}, err
 	}
+	g.fillIOEngine(&c.Changelogs.IOEngine)
 	g.fillCommonService(&c.CommonServer, &spec.InstanceSpec)
 	g.fillBusServer(&c.CommonServer, spec.NativeTransport)
 	g.fillPrimaryMaster(&c.PrimaryMaster)
@@ -465,6 +475,10 @@ func (g *NodeGenerator) getDataNodeConfigImpl(spec *ytv1.DataNodesSpec) (DataNod
 		return DataNodeServer{}, err
 	}
 
+	for i := range c.DataNode.StoreLocations {
+		g.fillIOEngine(&c.DataNode.StoreLocations[i].IOEngine)
+	}
+
 	g.fillCommonService(&c.CommonServer, &spec.InstanceSpec)
 	g.fillBusServer(&c.CommonServer, spec.NativeTransport)
 	return c, nil
@@ -482,6 +496,9 @@ func (g *NodeGenerator) getExecNodeConfigImpl(spec *ytv1.ExecNodesSpec) (ExecNod
 	c, err := getExecNodeServerCarcass(spec, &g.commonSpec)
 	if err != nil {
 		return c, err
+	}
+	for i := range c.DataNode.CacheLocations {
+		g.fillIOEngine(&c.DataNode.CacheLocations[i].IOEngine)
 	}
 	g.fillCommonService(&c.CommonServer, &spec.InstanceSpec)
 	g.fillBusServer(&c.CommonServer, spec.NativeTransport)

--- a/pkg/ytconfig/master.go
+++ b/pkg/ytconfig/master.go
@@ -8,7 +8,8 @@ import (
 )
 
 type MasterChangelogs struct {
-	Path string `yson:"path"`
+	Path     string    `yson:"path"`
+	IOEngine *IOEngine `yson:"io_engine,omitempty"`
 }
 
 type MasterSnapshots struct {

--- a/pkg/ytconfig/node.go
+++ b/pkg/ytconfig/node.go
@@ -26,12 +26,13 @@ const (
 )
 
 type StoreLocation struct {
-	Path                   string `yson:"path"`
-	MediumName             string `yson:"medium_name"`
-	Quota                  int64  `yson:"quota,omitempty"`
-	HighWatermark          int64  `yson:"high_watermark,omitempty"`
-	LowWatermark           int64  `yson:"low_watermark,omitempty"`
-	DisableWritesWatermark int64  `yson:"disable_writes_watermark,omitempty"`
+	Path                   string    `yson:"path"`
+	IOEngine               *IOEngine `yson:"io_config,omitempty"`
+	MediumName             string    `yson:"medium_name"`
+	Quota                  int64     `yson:"quota,omitempty"`
+	HighWatermark          int64     `yson:"high_watermark,omitempty"`
+	LowWatermark           int64     `yson:"low_watermark,omitempty"`
+	DisableWritesWatermark int64     `yson:"disable_writes_watermark,omitempty"`
 }
 
 type ResourceLimits struct {
@@ -40,8 +41,9 @@ type ResourceLimits struct {
 	NodeDedicatedCpu *float32 `yson:"node_dedicated_cpu,omitempty"`
 }
 
-type DiskLocation struct {
-	Path string `yson:"path"`
+type CacheLocation struct {
+	Path     string    `yson:"path"`
+	IOEngine *IOEngine `yson:"io_config,omitempty"`
 }
 
 type SlotLocation struct {
@@ -53,7 +55,7 @@ type SlotLocation struct {
 
 type DataNode struct {
 	StoreLocations []StoreLocation `yson:"store_locations"`
-	CacheLocations []DiskLocation  `yson:"cache_locations"`
+	CacheLocations []CacheLocation `yson:"cache_locations"`
 	BlockCache     BlockCache      `yson:"block_cache"`
 	BlocksExtCache Cache           `yson:"blocks_ext_cache"`
 	ChunkMetaCache Cache           `yson:"chunk_meta_cache"`
@@ -434,7 +436,7 @@ func getExecNodeServerCarcass(spec *ytv1.ExecNodesSpec, commonSpec *ytv1.CommonS
 	c.ResourceLimits = getExecNodeResourceLimits(spec)
 
 	for _, location := range ytv1.FindAllLocations(spec.Locations, ytv1.LocationTypeChunkCache) {
-		c.DataNode.CacheLocations = append(c.DataNode.CacheLocations, DiskLocation{
+		c.DataNode.CacheLocations = append(c.DataNode.CacheLocations, CacheLocation{
 			Path: location.Path,
 		})
 	}

--- a/ytop-chart/templates/remoteexecnodes-crd.yaml
+++ b/ytop-chart/templates/remoteexecnodes-crd.yaml
@@ -646,6 +646,10 @@ spec:
                 items:
                   type: string
                 type: array
+              ephemeralCluster:
+                default: false
+                description: Allow prioritizing performance over data safety.
+                type: boolean
               extraPodAnnotations:
                 additionalProperties:
                   type: string

--- a/ytop-chart/templates/ytsaurus-crd.yaml
+++ b/ytop-chart/templates/ytsaurus-crd.yaml
@@ -7121,6 +7121,10 @@ spec:
               enableFullUpdate:
                 default: true
                 type: boolean
+              ephemeralCluster:
+                default: false
+                description: Allow prioritizing performance over data safety.
+                type: boolean
               execNodes:
                 items:
                   properties:


### PR DESCRIPTION
- Add option for creating ephemeral cluster
  This is high-level option which could effects on its own or
  allow other "dangerous" options.
  
  For now it simply disables "sync" in all disk I/O engines.
  
- Use ephemeral clusters in tests
  
