### PR TITLE
Rename mock ctrl because we want that name for the imports

### DIFF
--- a/pkg/components/suite_test.go
+++ b/pkg/components/suite_test.go
@@ -16,12 +16,12 @@ import (
 	mock_yt "github.com/ytsaurus/yt-k8s-operator/pkg/mock"
 )
 
-var ctrl *gomock.Controller
+var mockCtrl *gomock.Controller
 
 func TestComponents(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	ctrl = gomock.NewController(t)
+	mockCtrl = gomock.NewController(t)
 
 	RunSpecs(t, "Components fake suite")
 }

--- a/pkg/components/tablet_node_test.go
+++ b/pkg/components/tablet_node_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Tablet node test", func() {
 	var client client.WithWatch
 
 	BeforeEach(func() {
-		mockYtClient = mock_yt.NewMockClient(ctrl)
+		mockYtClient = mock_yt.NewMockClient(mockCtrl)
 
 		masterVolumeSize, _ := resource.ParseQuantity("1Gi")
 


### PR DESCRIPTION
Our linter says that `"sigs.k8s.io/controller-runtime"` should be imported as `ctrl` and is impossible to do with high level `ctrl` variable.