### PR TITLE
Fix go version for release & switch to GH infra

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,56 +1,27 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'release/0\.[0-9]+\.[0-9]+'
 
 jobs:
-  start-vm:
-    name: Start VM
-    runs-on: ubuntu-latest
-    outputs:
-      label: ${{ steps.start-yc-runner.outputs.label }}
-      instance-id: ${{ steps.start-yc-runner.outputs.instance-id }}
-    steps:
-      - name: Start YC runner
-        id: start-yc-runner
-        uses: yc-actions/yc-github-runner@v1
-        with:
-          mode: start
-          yc-sa-json-credentials: ${{ secrets.YC_SA_JSON_CREDENTIALS }}
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          folder-id: ${{ vars.YC_FOLDER_ID }}
-          image-id: ${{ vars.YC_DEFAULT_IMAGE_ID }}
-          zone-id: ${{ vars.YC_ZONE_ID }}
-          subnet-id: ${{ vars.YC_SUBNET_ID }}
-          cores: 4
-          memory: 8GB
-          core-fraction: 100
-          disk-type: network-ssd-nonreplicated
-          disk-size: 93GB
-
-  checkout:
-    name: Checkout sources
-    needs: start-vm
-    runs-on: ${{ needs.start-vm.outputs.label }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
   release:
     name: Run release
-    needs:
-      - start-vm
-      - checkout
-    runs-on: ${{ needs.start-vm.outputs.label }}
+    runs-on: ubuntu-latest
     env:
       HOME: /root
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
+      - name: checkout sources
+        uses: actions/checkout@v3
         with:
-          go-version: 1.19
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
 
       - name: Set up Helm
         uses: azure/setup-helm@v1
@@ -82,28 +53,9 @@ jobs:
         run: |
           make release RELEASE_VERSION=${{ steps.tag.outputs.RELEASE_VERSION }}
 
-  stop-vm:
-    name: Stop VM
-    needs:
-      - start-vm
-      - release
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    steps:
-      - name: Stop YC runner
-        uses: yc-actions/yc-github-runner@v1
-        with:
-          mode: stop
-          yc-sa-json-credentials: ${{ secrets.YC_SA_JSON_CREDENTIALS }}
-          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          label: ${{ needs.start-vm.outputs.label }}
-          instance-id: ${{ needs.start-vm.outputs.instance-id }}
-
   send-notifications:
     name: Send notifications
-    needs:
-      - stop-vm
-    runs-on: trampoline
+    runs-on: ubuntu-latest
     if: ${{ failure() }}
     steps:
       - name: Send telegram message


### PR DESCRIPTION
Current go version fails with 
```
Error: /root/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.5/pkg/cache/cache.go:412:58: fields.Selector does not implement comparable
```
in go vet.

This doesn't affect code or workflows other than release one.