### PR TITLE
Fix nightly release publish

### DIFF
--- a/.github/workflows/check_main.yaml
+++ b/.github/workflows/check_main.yaml
@@ -28,6 +28,11 @@ jobs:
       - check-compat
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: Docker Hub login
         run: |
           echo '${{ secrets.DOCKER_HUB_PASSWORD }}' | docker login --username ${{ secrets.DOCKER_HUB_LOGIN}} --password-stdin


### PR DESCRIPTION
Job was moved out of place with sources, so git fails.
Only affects main flow, so no need to run pr checks