### PR TITLE
Refactor NeedsFullUpdate status

### DIFF
--- a/controllers/component_manager.go
+++ b/controllers/component_manager.go
@@ -25,8 +25,7 @@ type ComponentManager struct {
 type ComponentManagerStatus struct {
 	needSync           bool
 	needInit           bool
-	needFullUpdate     bool
-	needLocalUpdate    []components.Component
+	needUpdate         []components.Component
 	allReadyOrUpdating bool
 }
 
@@ -143,8 +142,7 @@ func NewComponentManager(
 	status := ComponentManagerStatus{
 		needInit:           false,
 		needSync:           false,
-		needFullUpdate:     false,
-		needLocalUpdate:    nil,
+		needUpdate:         nil,
 		allReadyOrUpdating: true,
 	}
 	for _, c := range allComponents {
@@ -162,15 +160,8 @@ func NewComponentManager(
 		c.SetReadyCondition(componentStatus)
 		syncStatus := componentStatus.SyncStatus
 
-		if syncStatus == components.SyncStatusNeedFullUpdate {
-			status.needFullUpdate = true
-		}
-
 		if syncStatus == components.SyncStatusNeedLocalUpdate {
-			if status.needLocalUpdate == nil {
-				status.needLocalUpdate = make([]components.Component, 0)
-			}
-			status.needLocalUpdate = append(status.needLocalUpdate, c)
+			status.needUpdate = append(status.needUpdate, c)
 		}
 
 		if !components.IsRunningStatus(syncStatus) {
@@ -247,12 +238,8 @@ func (cm *ComponentManager) needInit() bool {
 	return cm.status.needInit
 }
 
-func (cm *ComponentManager) needFullUpdate() bool {
-	return cm.status.needFullUpdate
-}
-
-func (cm *ComponentManager) needLocalUpdate() []components.Component {
-	return cm.status.needLocalUpdate
+func (cm *ComponentManager) needUpdate() []components.Component {
+	return cm.status.needUpdate
 }
 
 func (cm *ComponentManager) allReadyOrUpdating() bool {

--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -15,7 +15,6 @@ type SyncStatus string
 
 const (
 	SyncStatusBlocked         SyncStatus = "Blocked"
-	SyncStatusNeedFullUpdate  SyncStatus = "NeedFullUpdate"
 	SyncStatusNeedLocalUpdate SyncStatus = "NeedLocalUpdate"
 	SyncStatusPending         SyncStatus = "Pending"
 	SyncStatusReady           SyncStatus = "Ready"
@@ -23,7 +22,7 @@ const (
 )
 
 func IsRunningStatus(status SyncStatus) bool {
-	return status == SyncStatusReady || status == SyncStatusNeedLocalUpdate || status == SyncStatusNeedFullUpdate
+	return status == SyncStatusReady || status == SyncStatusNeedLocalUpdate
 }
 
 type ComponentStatus struct {

--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -285,7 +285,7 @@ func (m *Master) doSync(ctx context.Context, dry bool) (ComponentStatus, error) 
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(m.ytsaurus.GetClusterState()) && m.server.needUpdate() {
-		return SimpleStatus(SyncStatusNeedFullUpdate), err
+		return SimpleStatus(SyncStatusNeedLocalUpdate), err
 	}
 
 	if m.ytsaurus.GetClusterState() == ytv1.ClusterStateUpdating {

--- a/pkg/components/tablet_node.go
+++ b/pkg/components/tablet_node.go
@@ -84,7 +84,7 @@ func (tn *TabletNode) doSync(ctx context.Context, dry bool) (ComponentStatus, er
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(tn.ytsaurus.GetClusterState()) && tn.server.needUpdate() {
-		return SimpleStatus(SyncStatusNeedFullUpdate), err
+		return SimpleStatus(SyncStatusNeedLocalUpdate), err
 	}
 
 	if tn.ytsaurus.GetClusterState() == ytv1.ClusterStateUpdating {


### PR DESCRIPTION
Get rid of master & tnds returning NeedFullUpdate so we can control on component manager leve whether we need full update or not. This is need to be able to add more update strategies in the future (#211).

Change is expected to be backward compatible.

Also added an extra test for not-updating case.