### PR TITLE
UpdateSelector: add field

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -547,9 +547,9 @@ type YtsaurusSpec struct {
 	//+optional
 	EnableFullUpdate bool `json:"enableFullUpdate"`
 	//+optional
-	// UpdateStrategy is an experimental field. Behaviour may change.
-	// If UpdateStrategy is not empty EnableFullUpdate is ignored.
-	UpdateStrategy UpdateStrategy `json:"updateStrategy"`
+	// UpdateSelector is an experimental field. Behaviour may change.
+	// If UpdateSelector is not empty EnableFullUpdate is ignored.
+	UpdateSelector UpdateSelector `json:"updateSelector"`
 
 	Bootstrap *BootstrapSpec `json:"bootstrap,omitempty"`
 
@@ -622,22 +622,33 @@ type TabletCellBundleInfo struct {
 	TabletCellCount int    `yson:"tablet_cell_count,attr" json:"tabletCellCount"`
 }
 
-type UpdateStrategy string
+type UpdateSelector string
 
 const (
-	UpdateStrategyNone            UpdateStrategy = ""
-	UpdateStrategyBlocked         UpdateStrategy = "Blocked"
-	UpdateStrategyStatelessOnly   UpdateStrategy = "StatelessOnly"
-	UpdateStrategyMasterOnly      UpdateStrategy = "MasterOnly"
-	UpdateStrategyTabletNodesOnly UpdateStrategy = "TabletNodesOnly"
-	UpdateStrategyFull            UpdateStrategy = "Full"
+	UpdateSelectorNone            UpdateSelector = ""
+	UpdateSelectorNothing         UpdateSelector = "Nothing"
+	UpdateSelectorStatelessOnly   UpdateSelector = "StatelessOnly"
+	UpdateSelectorMasterOnly      UpdateSelector = "MasterOnly"
+	UpdateSelectorTabletNodesOnly UpdateSelector = "TabletNodesOnly"
+	UpdateSelectorExecNodesOnly   UpdateSelector = "ExecNodesOnly"
+	UpdateSelectorEverything      UpdateSelector = "Everything"
+)
+
+type UpdateFlow string
+
+const (
+	UpdateFlowNone        UpdateFlow = ""
+	UpdateFlowStateless   UpdateFlow = "Stateless"
+	UpdateFlowMaster      UpdateFlow = "Master"
+	UpdateFlowTabletNodes UpdateFlow = "TabletNodes"
+	UpdateFlowFull        UpdateFlow = "Full"
 )
 
 type UpdateStatus struct {
 	//+kubebuilder:default:=None
 	State                 UpdateState            `json:"state,omitempty"`
 	Components            []string               `json:"components,omitempty"`
-	Strategy              UpdateStrategy         `json:"updateStrategy,omitempty"`
+	Flow                  UpdateFlow             `json:"flow,omitempty"`
 	Conditions            []metav1.Condition     `json:"conditions,omitempty"`
 	TabletCellBundles     []TabletCellBundleInfo `json:"tabletCellBundles,omitempty"`
 	MasterMonitoringPaths []string               `json:"masterMonitoringPaths,omitempty"`

--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -546,6 +546,10 @@ type YtsaurusSpec struct {
 	//+kubebuilder:default:=true
 	//+optional
 	EnableFullUpdate bool `json:"enableFullUpdate"`
+	//+optional
+	// UpdateStrategy is an experimental field. Behaviour may change.
+	// If UpdateStrategy is not empty EnableFullUpdate is ignored.
+	UpdateStrategy UpdateStrategy `json:"updateStrategy"`
 
 	Bootstrap *BootstrapSpec `json:"bootstrap,omitempty"`
 
@@ -618,10 +622,22 @@ type TabletCellBundleInfo struct {
 	TabletCellCount int    `yson:"tablet_cell_count,attr" json:"tabletCellCount"`
 }
 
+type UpdateStrategy string
+
+const (
+	UpdateStrategyNone            UpdateStrategy = ""
+	UpdateStrategyBlocked         UpdateStrategy = "Blocked"
+	UpdateStrategyStatelessOnly   UpdateStrategy = "StatelessOnly"
+	UpdateStrategyMasterOnly      UpdateStrategy = "MasterOnly"
+	UpdateStrategyTabletNodesOnly UpdateStrategy = "TabletNodesOnly"
+	UpdateStrategyFull            UpdateStrategy = "Full"
+)
+
 type UpdateStatus struct {
 	//+kubebuilder:default:=None
 	State                 UpdateState            `json:"state,omitempty"`
 	Components            []string               `json:"components,omitempty"`
+	Strategy              UpdateStrategy         `json:"updateStrategy,omitempty"`
 	Conditions            []metav1.Condition     `json:"conditions,omitempty"`
 	TabletCellBundles     []TabletCellBundleInfo `json:"tabletCellBundles,omitempty"`
 	MasterMonitoringPaths []string               `json:"masterMonitoringPaths,omitempty"`

--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -625,13 +625,22 @@ type TabletCellBundleInfo struct {
 type UpdateSelector string
 
 const (
-	UpdateSelectorNone            UpdateSelector = ""
-	UpdateSelectorNothing         UpdateSelector = "Nothing"
-	UpdateSelectorStatelessOnly   UpdateSelector = "StatelessOnly"
-	UpdateSelectorMasterOnly      UpdateSelector = "MasterOnly"
+	// UpdateSelectorUnspecified means that selector is disabled and would be ignored completely.
+	UpdateSelectorUnspecified UpdateSelector = ""
+	// UpdateSelectorNothing means that no component could be updated.
+	UpdateSelectorNothing UpdateSelector = "Nothing"
+	// UpdateSelectorStatelessOnly means that only stateless components (everything but master and tablet nodes)
+	// could be updated.
+	UpdateSelectorStatelessOnly UpdateSelector = "StatelessOnly"
+	// UpdateSelectorMasterOnly means that only master could be updated.
+	UpdateSelectorMasterOnly UpdateSelector = "MasterOnly"
+	// UpdateSelectorTabletNodesOnly means that only tablet nodes could be updated
 	UpdateSelectorTabletNodesOnly UpdateSelector = "TabletNodesOnly"
-	UpdateSelectorExecNodesOnly   UpdateSelector = "ExecNodesOnly"
-	UpdateSelectorEverything      UpdateSelector = "Everything"
+	// UpdateSelectorExecNodesOnly means that only tablet nodes could be updated
+	UpdateSelectorExecNodesOnly UpdateSelector = "ExecNodesOnly"
+	// UpdateSelectorEverything means that all components could be updated.
+	// With this setting and if master or tablet nodes need update all the components would be updated.
+	UpdateSelectorEverything UpdateSelector = "Everything"
 )
 
 type UpdateFlow string
@@ -646,8 +655,11 @@ const (
 
 type UpdateStatus struct {
 	//+kubebuilder:default:=None
-	State                 UpdateState            `json:"state,omitempty"`
-	Components            []string               `json:"components,omitempty"`
+	State      UpdateState `json:"state,omitempty"`
+	Components []string    `json:"components,omitempty"`
+	// Flow is an internal field that is needed to persist the chosen flow until the end of an update.
+	// Flow can be on of ""(unspecified), Stateless, Master, TabletNodes, Full and update cluster stage
+	// executes steps corresponding to that update flow.
 	Flow                  UpdateFlow             `json:"flow,omitempty"`
 	Conditions            []metav1.Condition     `json:"conditions,omitempty"`
 	TabletCellBundles     []TabletCellBundleInfo `json:"tabletCellBundles,omitempty"`

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -33433,8 +33433,8 @@ spec:
                 type: object
               uiImage:
                 type: string
-              updateStrategy:
-                description: UpdateStrategy is an experimental field. Behaviour may
+              updateSelector:
+                description: UpdateSelector is an experimental field. Behaviour may
                   change.
                 type: string
               useIpv4:
@@ -35887,6 +35887,8 @@ spec:
                       - type
                       type: object
                     type: array
+                  flow:
+                    type: string
                   masterMonitoringPaths:
                     items:
                       type: string
@@ -35906,8 +35908,6 @@ spec:
                       - tabletCellCount
                       type: object
                     type: array
-                  updateStrategy:
-                    type: string
                 type: object
             type: object
         type: object

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -33433,6 +33433,10 @@ spec:
                 type: object
               uiImage:
                 type: string
+              updateStrategy:
+                description: UpdateStrategy is an experimental field. Behaviour may
+                  change.
+                type: string
               useIpv4:
                 default: false
                 type: boolean
@@ -35902,6 +35906,8 @@ spec:
                       - tabletCellCount
                       type: object
                     type: array
+                  updateStrategy:
+                    type: string
                 type: object
             type: object
         type: object

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -35888,6 +35888,8 @@ spec:
                       type: object
                     type: array
                   flow:
+                    description: Flow is an internal field that is needed to persist
+                      the chosen flow until the en
                     type: string
                   masterMonitoringPaths:
                     items:

--- a/docs/api.md
+++ b/docs/api.md
@@ -1489,9 +1489,24 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `state` _[UpdateState](#updatestate)_ |  | None |  |
 | `components` _string array_ |  |  |  |
+| `updateStrategy` _[UpdateStrategy](#updatestrategy)_ |  |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ |  |  |  |
 | `tabletCellBundles` _[TabletCellBundleInfo](#tabletcellbundleinfo) array_ |  |  |  |
 | `masterMonitoringPaths` _string array_ |  |  |  |
+
+
+#### UpdateStrategy
+
+_Underlying type:_ _string_
+
+
+
+
+
+_Appears in:_
+- [UpdateStatus](#updatestatus)
+- [YtsaurusSpec](#ytsaurusspec)
+
 
 
 #### YQLAgentSpec
@@ -1577,6 +1592,7 @@ _Appears in:_
 | `oauthService` _[OauthServiceSpec](#oauthservicespec)_ |  |  |  |
 | `isManaged` _boolean_ |  | true |  |
 | `enableFullUpdate` _boolean_ |  | true |  |
+| `updateStrategy` _[UpdateStrategy](#updatestrategy)_ | UpdateStrategy is an experimental field. Behaviour may change.<br />If UpdateStrategy is not empty EnableFullUpdate is ignored. |  |  |
 | `bootstrap` _[BootstrapSpec](#bootstrapspec)_ |  |  |  |
 | `discovery` _[DiscoverySpec](#discoveryspec)_ |  |  |  |
 | `primaryMasters` _[MastersSpec](#mastersspec)_ |  |  |  |

--- a/docs/api.md
+++ b/docs/api.md
@@ -1515,7 +1515,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `state` _[UpdateState](#updatestate)_ |  | None |  |
 | `components` _string array_ |  |  |  |
-| `flow` _[UpdateFlow](#updateflow)_ |  |  |  |
+| `flow` _[UpdateFlow](#updateflow)_ | Flow is an internal field that is needed to persist the chosen flow until the end of an update.<br />Flow can be on of ""(unspecified), Stateless, Master, TabletNodes, Full and update cluster stage<br />executes steps corresponding to that update flow. |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ |  |  |  |
 | `tabletCellBundles` _[TabletCellBundleInfo](#tabletcellbundleinfo) array_ |  |  |  |
 | `masterMonitoringPaths` _string array_ |  |  |  |

--- a/docs/api.md
+++ b/docs/api.md
@@ -1461,6 +1461,32 @@ _Appears in:_
 | `group` _string_ |  |  |  |
 
 
+#### UpdateFlow
+
+_Underlying type:_ _string_
+
+
+
+
+
+_Appears in:_
+- [UpdateStatus](#updatestatus)
+
+
+
+#### UpdateSelector
+
+_Underlying type:_ _string_
+
+
+
+
+
+_Appears in:_
+- [YtsaurusSpec](#ytsaurusspec)
+
+
+
 #### UpdateState
 
 _Underlying type:_ _string_
@@ -1489,24 +1515,10 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `state` _[UpdateState](#updatestate)_ |  | None |  |
 | `components` _string array_ |  |  |  |
-| `updateStrategy` _[UpdateStrategy](#updatestrategy)_ |  |  |  |
+| `flow` _[UpdateFlow](#updateflow)_ |  |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ |  |  |  |
 | `tabletCellBundles` _[TabletCellBundleInfo](#tabletcellbundleinfo) array_ |  |  |  |
 | `masterMonitoringPaths` _string array_ |  |  |  |
-
-
-#### UpdateStrategy
-
-_Underlying type:_ _string_
-
-
-
-
-
-_Appears in:_
-- [UpdateStatus](#updatestatus)
-- [YtsaurusSpec](#ytsaurusspec)
-
 
 
 #### YQLAgentSpec
@@ -1592,7 +1604,7 @@ _Appears in:_
 | `oauthService` _[OauthServiceSpec](#oauthservicespec)_ |  |  |  |
 | `isManaged` _boolean_ |  | true |  |
 | `enableFullUpdate` _boolean_ |  | true |  |
-| `updateStrategy` _[UpdateStrategy](#updatestrategy)_ | UpdateStrategy is an experimental field. Behaviour may change.<br />If UpdateStrategy is not empty EnableFullUpdate is ignored. |  |  |
+| `updateSelector` _[UpdateSelector](#updateselector)_ | UpdateSelector is an experimental field. Behaviour may change.<br />If UpdateSelector is not empty EnableFullUpdate is ignored. |  |  |
 | `bootstrap` _[BootstrapSpec](#bootstrapspec)_ |  |  |  |
 | `discovery` _[DiscoverySpec](#discoveryspec)_ |  |  |  |
 | `primaryMasters` _[MastersSpec](#mastersspec)_ |  |  |  |

--- a/ytop-chart/templates/ytsaurus-crd.yaml
+++ b/ytop-chart/templates/ytsaurus-crd.yaml
@@ -33220,6 +33220,10 @@ spec:
                 type: object
               uiImage:
                 type: string
+              updateStrategy:
+                description: UpdateStrategy is an experimental field. Behaviour may
+                  change.
+                type: string
               useIpv4:
                 default: false
                 type: boolean
@@ -35670,6 +35674,8 @@ spec:
                       - tabletCellCount
                       type: object
                     type: array
+                  updateStrategy:
+                    type: string
                 type: object
             type: object
         type: object

--- a/ytop-chart/templates/ytsaurus-crd.yaml
+++ b/ytop-chart/templates/ytsaurus-crd.yaml
@@ -35656,6 +35656,8 @@ spec:
                       type: object
                     type: array
                   flow:
+                    description: Flow is an internal field that is needed to persist
+                      the chosen flow until the en
                     type: string
                   masterMonitoringPaths:
                     items:

--- a/ytop-chart/templates/ytsaurus-crd.yaml
+++ b/ytop-chart/templates/ytsaurus-crd.yaml
@@ -33220,8 +33220,8 @@ spec:
                 type: object
               uiImage:
                 type: string
-              updateStrategy:
-                description: UpdateStrategy is an experimental field. Behaviour may
+              updateSelector:
+                description: UpdateSelector is an experimental field. Behaviour may
                   change.
                 type: string
               useIpv4:
@@ -35655,6 +35655,8 @@ spec:
                       - type
                       type: object
                     type: array
+                  flow:
+                    type: string
                   masterMonitoringPaths:
                     items:
                       type: string
@@ -35674,8 +35676,6 @@ spec:
                       - tabletCellCount
                       type: object
                     type: array
-                  updateStrategy:
-                    type: string
                 type: object
             type: object
         type: object


### PR DESCRIPTION
Introduced new `UpdateSelector` field in spec which can be one of: 
    - `""` (empty) — field is not considered at all, which is backward compatible with using `EnableFullUpdate` 
    - `Nothing` — no component can be updated (logs will indicate a reason)
    - `MasterOnly` — only master will be updated (flow with safety checks/safe mode/snapshots/exit read only), other components' updates will be ignored
    - `TabletNodesOnly` — only tablet nodes will be updated (with removing tablet bundles and recreating them after the update)
    - `ExecNodesOnly` — only exec nodes will be updated (without extra steps, because it is stateless component)
    - `StatelessOnly` — everything apart from master and tablet nodes will be updated (currently it is the same as so called local update flow)
    - `Everything ` — everything will be updated at once (currently it is the same as so called Full update flow)
I've called the new field experimental since I'm not sure if we will want to support all that behaviours in the future after #115 

Also `Flow` field is added to `UpdateStatus` which is persisted with transition to the Updating status. Usage can be seen in #239