### PR TITLE
Add configuration for solomon exporter: specify host and some instance tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ else
 DOCKER_BUILD_ARGS += --build-arg VERSION="$(OPERATOR_TAG)"
 endif
 DOCKER_BUILD_ARGS += --build-arg REVISION="$(shell git rev-parse HEAD)"
-DOCKER_BUILD_ARGS += --build-arg BUILD_DATE="$(shell date -Iseconds)"
+DOCKER_BUILD_ARGS += --build-arg BUILD_DATE="$(shell date --rfc-3339=seconds)"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ else
 DOCKER_BUILD_ARGS += --build-arg VERSION="$(OPERATOR_TAG)"
 endif
 DOCKER_BUILD_ARGS += --build-arg REVISION="$(shell git rev-parse HEAD)"
-DOCKER_BUILD_ARGS += --build-arg BUILD_DATE="$(shell date --rfc-3339=seconds)"
+DOCKER_BUILD_ARGS += --build-arg BUILD_DATE="$(shell date -Iseconds)"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/pkg/components/volume.go
+++ b/pkg/components/volume.go
@@ -104,11 +104,19 @@ func getConfigPostprocessingCommand(configFileName string) string {
 		return fmt.Sprintf("sed -i -s \"s/{%v}/${%v}/g\" %v; ", envVar, envVar, configPath)
 	}
 
+	substitutePlaceholderWithCommand := func(placeholder string, command string) string {
+		// Replace placeholder {placeholder} with the output of the given command.
+		return fmt.Sprintf("sed -i -s \"s/{%v}/$(%v)/g\" %v; ", placeholder, command, configPath)
+	}
+
 	postprocessScript := fmt.Sprintf("cp %v %v; ", configTemplatePath, configPath)
 
 	for _, envVar := range getConfigPostprocessEnv() {
 		postprocessScript += substituteEnvCommand(envVar.Name)
 	}
+
+	postprocessScript += substitutePlaceholderWithCommand("POD_FQDN", "hostname -f")
+	postprocessScript += substitutePlaceholderWithCommand("POD_SHORT_HOSTNAME", "hostname -s")
 
 	command += fmt.Sprintf("echo '%v' > %v; ", postprocessScript, postprocessScriptPath)
 	command += fmt.Sprintf("chmod +x '%v'; ", postprocessScriptPath)

--- a/pkg/ytconfig/canondata/TestGetControllerAgentsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetControllerAgentsConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetControllerAgentsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetControllerAgentsConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetDataNodeConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetDataNodeConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetDataNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeWithoutYtsaurusConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetDataNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeWithoutYtsaurusConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetDiscoveryConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDiscoveryConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetDiscoveryConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDiscoveryConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetExecNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeWithoutYtsaurusConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetExecNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeWithoutYtsaurusConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetHTTPProxyConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetHTTPProxyConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetHTTPProxyConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetHTTPProxyConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetMasterCachesConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterCachesConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetMasterCachesConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterCachesConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetMasterCachesWithFixedHostsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterCachesWithFixedHostsConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetMasterCachesWithFixedHostsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterCachesWithFixedHostsConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetMasterConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetMasterConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             debug={

--- a/pkg/ytconfig/canondata/TestGetMasterWithFixedHostsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterWithFixedHostsConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetMasterWithFixedHostsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterWithFixedHostsConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             debug={

--- a/pkg/ytconfig/canondata/TestGetQueryTrackerConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetQueryTrackerConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetQueryTrackerConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetQueryTrackerConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetQueueAgentConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetQueueAgentConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetQueueAgentConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetQueueAgentConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetRPCProxyConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetRPCProxyConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetRPCProxyConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetRPCProxyConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetRPCProxyWithoutOauthConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetRPCProxyWithoutOauthConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetRPCProxyWithoutOauthConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetRPCProxyWithoutOauthConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetSchedulerConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetSchedulerConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetSchedulerConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetSchedulerConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetSchedulerWithFixedMasterHostsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetSchedulerWithFixedMasterHostsConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetSchedulerWithFixedMasterHostsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetSchedulerWithFixedMasterHostsConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetTCPProxyConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetTCPProxyConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetTCPProxyConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetTCPProxyConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetTabletNodeConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetTabletNodeConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetTabletNodeConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetTabletNodeConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetTabletNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetTabletNodeWithoutYtsaurusConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             info={

--- a/pkg/ytconfig/canondata/TestGetTabletNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetTabletNodeWithoutYtsaurusConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetYQLAgentConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYQLAgentConfig/test.canondata
@@ -7,7 +7,7 @@
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={
-            "k8s_pod_name"="{K8S_POD_NAME}";
+            pod="{K8S_POD_NAME}";
         };
     };
     logging={

--- a/pkg/ytconfig/canondata/TestGetYQLAgentConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYQLAgentConfig/test.canondata
@@ -4,6 +4,12 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    "solomon_exporter"={
+        host="{POD_SHORT_HOSTNAME}";
+        "instance_tags"={
+            "k8s_pod_name"="{K8S_POD_NAME}";
+        };
+    };
     logging={
         writers={
             debug={

--- a/pkg/ytconfig/common.go
+++ b/pkg/ytconfig/common.go
@@ -56,6 +56,11 @@ type AddressResolver struct {
 	LocalhostNameOverride *string `yson:"localhost_name_override,omitempty"`
 }
 
+type SolomonExporter struct {
+	Host         *string           `yson:"host,omitempty"`
+	InstanceTags map[string]string `yson:"instance_tags,omitempty"`
+}
+
 type PemBlob struct {
 	FileName string `yson:"file_name,omitempty"`
 	Value    string `yson:"value,omitempty"`
@@ -95,6 +100,7 @@ type BusServer struct {
 // BasicServer is used as a basic config for basic components, such as clocks or discovery.
 type BasicServer struct {
 	AddressResolver AddressResolver `yson:"address_resolver"`
+	SolomonExporter SolomonExporter `yson:"solomon_exporter"`
 	Logging         Logging         `yson:"logging"`
 	MonitoringPort  int32           `yson:"monitoring_port"`
 	RPCPort         int32           `yson:"rpc_port"`

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -156,7 +156,7 @@ func (g *BaseGenerator) fillAddressResolver(c *AddressResolver) {
 func (g *BaseGenerator) fillSolomonExporter(c *SolomonExporter) {
 	c.Host = ptr.String("{POD_SHORT_HOSTNAME}")
 	c.InstanceTags = map[string]string{
-		"k8s_pod_name": "{K8S_POD_NAME}",
+		"pod": "{K8S_POD_NAME}",
 	}
 }
 

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -153,6 +153,13 @@ func (g *BaseGenerator) fillAddressResolver(c *AddressResolver) {
 	c.Retries = &retries
 }
 
+func (g *BaseGenerator) fillSolomonExporter(c *SolomonExporter) {
+	c.Host = ptr.String("{POD_SHORT_HOSTNAME}")
+	c.InstanceTags = map[string]string{
+		"k8s_pod_name": "{K8S_POD_NAME}",
+	}
+}
+
 func (g *BaseGenerator) fillPrimaryMaster(c *MasterCell) {
 	c.Addresses = g.getMasterAddresses()
 	c.Peers = g.getMasterHydraPeers()
@@ -185,6 +192,7 @@ func (g *BaseGenerator) fillCypressAnnotations(c *map[string]any) {
 func (g *BaseGenerator) fillCommonService(c *CommonServer, s *ytv1.InstanceSpec) {
 	// ToDo(psushin): enable porto resource tracker?
 	g.fillAddressResolver(&c.AddressResolver)
+	g.fillSolomonExporter(&c.SolomonExporter)
 	g.fillClusterConnection(&c.ClusterConnection, s.NativeTransport)
 	g.fillCypressAnnotations(&c.CypressAnnotations)
 	c.TimestampProviders.Addresses = g.getMasterAddresses()


### PR DESCRIPTION
When the solomon_exporter section is not configured metrics are exported without any host-related labels, which isn't very convenient.

Tested locally that the sensors from `curl localhost:<monitoring_port>/solomon/all` are now enriched with the added attributes.