### PR TITLE
Exclude "Concurrency" debug logging in sample configs

### DIFF
--- a/config/samples/cluster_v1_cri.yaml
+++ b/config/samples/cluster_v1_cri.yaml
@@ -69,7 +69,7 @@ spec:
           maxSegmentCountToKeep: 1000
         categoriesFilter:
           type: exclude
-          values: ["Bus"]
+          values: [ "Bus", "Concurrency" ]
       - name: info
         minLogLevel: info
         writerType: file

--- a/config/samples/cluster_v1_demo.yaml
+++ b/config/samples/cluster_v1_demo.yaml
@@ -93,7 +93,7 @@ spec:
             rotationPeriodMilliseconds: 900000
           categoriesFilter:
             type: exclude
-            values: [ "Bus" ]
+            values: [ "Bus", "Concurrency" ]
         - name: info
           minLogLevel: info
           writerType: file

--- a/config/samples/cluster_v1_local.yaml
+++ b/config/samples/cluster_v1_local.yaml
@@ -19,7 +19,7 @@ spec:
           rotationPeriodMilliseconds: 900000
         categoriesFilter:
           type: exclude
-          values: ["Bus"]
+          values: [ "Bus", "Concurrency" ]
       - name: info
         minLogLevel: info
         writerType: file
@@ -124,7 +124,7 @@ spec:
             rotationPeriodMilliseconds: 900000
           categoriesFilter:
             type: exclude
-            values: [ "Bus" ]
+            values: [ "Bus", "Concurrency" ]
         - name: info
           minLogLevel: info
           writerType: file

--- a/config/samples/cluster_v1_remoteexecnodes.yaml
+++ b/config/samples/cluster_v1_remoteexecnodes.yaml
@@ -33,7 +33,7 @@ spec:
         maxSegmentCountToKeep: 1000
       categoriesFilter:
         type: exclude
-        values: ["Bus"]
+        values: [ "Bus", "Concurrency" ]
     - name: info
       minLogLevel: info
       writerType: file

--- a/config/samples/cluster_v1_tls.yaml
+++ b/config/samples/cluster_v1_tls.yaml
@@ -45,7 +45,7 @@ spec:
           rotationPeriodMilliseconds: 900000
         categoriesFilter:
           type: exclude
-          values: ["Bus"]
+          values: [ "Bus", "Concurrency" ]
       - name: info
         minLogLevel: info
         writerType: file


### PR DESCRIPTION
Its signal-to-noise ratio is very low.
