### PR TITLE
Added externalProxy parameter for UI

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -485,6 +485,10 @@ type UISpec struct {
 	Resources          corev1.ResourceRequirements `json:"resources,omitempty"`
 	InstanceCount      int32                       `json:"instanceCount,omitempty"`
 
+	// If defined it will be used for direct heavy url/commands like: read_table, write_table, etc.
+	//+optional
+	ExternalProxy *string `json:"externalProxy,omitempty"`
+	// Odin is a service for monitoring the availability of YTsaurus clusters.
 	//+optional
 	OdinBaseUrl *string `json:"odinBaseUrl,omitempty"`
 

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1480,6 +1480,11 @@ func (in *UISpec) DeepCopyInto(out *UISpec) {
 		**out = **in
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.ExternalProxy != nil {
+		in, out := &in.ExternalProxy, &out.ExternalProxy
+		*out = new(string)
+		**out = **in
+	}
 	if in.OdinBaseUrl != nil {
 		in, out := &in.OdinBaseUrl, &out.OdinBaseUrl
 		*out = new(string)

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -34214,6 +34214,10 @@ spec:
                   environment:
                     default: testing
                     type: string
+                  externalProxy:
+                    description: 'If defined it will be used for direct heavy url/commands
+                      like: read_table, write'
+                    type: string
                   extraEnvVariables:
                     items:
                       description: EnvVar represents an environment variable present
@@ -34327,6 +34331,8 @@ spec:
                     format: int32
                     type: integer
                   odinBaseUrl:
+                    description: Odin is a service for monitoring the availability
+                      of YTsaurus clusters.
                     type: string
                   resources:
                     description: ResourceRequirements describes the compute resource

--- a/docs/api.md
+++ b/docs/api.md
@@ -1544,7 +1544,8 @@ _Appears in:_
 | `useInsecureCookies` _boolean_ |  | true |  |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ |  |  |  |
 | `instanceCount` _integer_ |  |  |  |
-| `odinBaseUrl` _string_ |  |  |  |
+| `externalProxy` _string_ | If defined it will be used for direct heavy url/commands like: read_table, write_table, etc. |  |  |
+| `odinBaseUrl` _string_ | Odin is a service for monitoring the availability of YTsaurus clusters. |  |  |
 | `extraEnvVariables` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ |  |  |  |
 | `environment` _string_ |  | testing |  |
 | `theme` _string_ |  | lavander |  |

--- a/pkg/ytconfig/canondata/TestGetUIClustersConfigWithSettings/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetUIClustersConfigWithSettings/test.canondata
@@ -1,0 +1,19 @@
+{
+    clusters=[
+        {
+            id=test;
+            name=test;
+            proxy="http-proxies-lb-test.fake.svc.fake.zone";
+            externalProxy="https://my-external-proxy.example.com";
+            secure=%false;
+            authentication=basic;
+            group="My YTsaurus clusters";
+            theme="";
+            environment="";
+            description="My first YTsaurus. Handle with care.";
+            primaryMaster={
+                cellTag=0;
+            };
+        };
+    ];
+}

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -684,6 +684,7 @@ func (g *Generator) GetUIClustersConfig() ([]byte, error) {
 	c.ID = g.ytsaurus.Name
 	c.Name = g.ytsaurus.Name
 	c.Proxy = g.GetHTTPProxiesAddress(consts.DefaultHTTPProxyRole)
+	c.ExternalProxy = g.ytsaurus.Spec.UI.ExternalProxy
 	c.PrimaryMaster.CellTag = g.ytsaurus.Spec.PrimaryMasters.CellTag
 
 	c.Theme = g.ytsaurus.Spec.UI.Theme

--- a/pkg/ytconfig/generator_test.go
+++ b/pkg/ytconfig/generator_test.go
@@ -373,6 +373,13 @@ func TestGetUIClustersConfig(t *testing.T) {
 	canonize.Assert(t, cfg)
 }
 
+func TestGetUIClustersConfigWithSettings(t *testing.T) {
+	g := NewGenerator(withUICustom(getYtsaurus()), testClusterDomain)
+	cfg, err := g.GetUIClustersConfig()
+	require.NoError(t, err)
+	canonize.Assert(t, cfg)
+}
+
 func TestGetUICustomConfig(t *testing.T) {
 	g := NewGenerator(withUICustom(getYtsaurus()), testClusterDomain)
 	cfg, err := g.GetUICustomConfig()
@@ -616,8 +623,10 @@ func withUI(ytsaurus *ytv1.Ytsaurus) *ytv1.Ytsaurus {
 
 func withUICustom(ytsaurus *ytv1.Ytsaurus) *ytv1.Ytsaurus {
 	odinUrl := "http://odin-webservice.odin.svc.cluster.local"
+	externalProxy := "https://my-external-proxy.example.com"
 	ytsaurus.Spec.UI = &ytv1.UISpec{
-		OdinBaseUrl: &odinUrl,
+		ExternalProxy: &externalProxy,
+		OdinBaseUrl:   &odinUrl,
 	}
 	return ytsaurus
 }

--- a/pkg/ytconfig/ui.go
+++ b/pkg/ytconfig/ui.go
@@ -14,6 +14,7 @@ type UICluster struct {
 	ID             string               `yson:"id"`
 	Name           string               `yson:"name"`
 	Proxy          string               `yson:"proxy"`
+	ExternalProxy  *string              `yson:"externalProxy,omitempty"`
 	Secure         bool                 `yson:"secure"`
 	Authentication UIAuthenticationType `yson:"authentication"`
 	Group          string               `yson:"group"`

--- a/ytop-chart/templates/ytsaurus-crd.yaml
+++ b/ytop-chart/templates/ytsaurus-crd.yaml
@@ -34003,6 +34003,10 @@ spec:
                   environment:
                     default: testing
                     type: string
+                  externalProxy:
+                    description: 'If defined it will be used for direct heavy url/commands
+                      like: read_table, write'
+                    type: string
                   extraEnvVariables:
                     items:
                       description: EnvVar represents an environment variable present
@@ -34114,6 +34118,8 @@ spec:
                     format: int32
                     type: integer
                   odinBaseUrl:
+                    description: Odin is a service for monitoring the availability of
+                      YTsaurus clusters.
                     type: string
                   resources:
                     description: ResourceRequirements describes the compute resource


### PR DESCRIPTION
This parameter is described in ytsaurus-ui as:
> if defined it will be used instead of `proxy`-field for some direct heavy url/commands like: read_table, write_table, get-job-stderr, ...