### PR TITLE
Size as Quantity in LogRotationPolicy

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -154,10 +154,10 @@ type CategoriesFilter struct {
 }
 
 type LogRotationPolicy struct {
-	RotationPeriodMilliseconds *int64 `json:"rotationPeriodMilliseconds,omitempty" yson:"rotation_period,omitempty"`
-	MaxSegmentSize             *int64 `json:"maxSegmentSize,omitempty" yson:"max_segment_size,omitempty"`
-	MaxTotalSizeToKeep         *int64 `json:"maxTotalSizeToKeep,omitempty" yson:"max_total_size_to_keep,omitempty"`
-	MaxSegmentCountToKeep      *int64 `json:"maxSegmentCountToKeep,omitempty" yson:"max_segment_count_to_keep,omitempty"`
+	RotationPeriodMilliseconds *int64             `json:"rotationPeriodMilliseconds,omitempty"`
+	MaxSegmentSize             *resource.Quantity `json:"maxSegmentSize,omitempty"`
+	MaxTotalSizeToKeep         *resource.Quantity `json:"maxTotalSizeToKeep,omitempty"`
+	MaxSegmentCountToKeep      *int64             `json:"maxSegmentCountToKeep,omitempty"`
 }
 
 type BaseLoggerSpec struct {

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -817,13 +817,13 @@ func (in *LogRotationPolicy) DeepCopyInto(out *LogRotationPolicy) {
 	}
 	if in.MaxSegmentSize != nil {
 		in, out := &in.MaxSegmentSize, &out.MaxSegmentSize
-		*out = new(int64)
-		**out = **in
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	if in.MaxTotalSizeToKeep != nil {
 		in, out := &in.MaxTotalSizeToKeep, &out.MaxTotalSizeToKeep
-		*out = new(int64)
-		**out = **in
+		x := (*in).DeepCopy()
+		*out = &x
 	}
 	if in.MaxSegmentCountToKeep != nil {
 		in, out := &in.MaxSegmentCountToKeep, &out.MaxSegmentCountToKeep

--- a/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
@@ -832,11 +832,17 @@ spec:
                           format: int64
                           type: integer
                         maxSegmentSize:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         maxTotalSizeToKeep:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         rotationPeriodMilliseconds:
                           format: int64
                           type: integer
@@ -979,11 +985,17 @@ spec:
                           format: int64
                           type: integer
                         maxSegmentSize:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         maxTotalSizeToKeep:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         rotationPeriodMilliseconds:
                           format: int64
                           type: integer
@@ -1171,11 +1183,17 @@ spec:
                           format: int64
                           type: integer
                         maxSegmentSize:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         maxTotalSizeToKeep:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         rotationPeriodMilliseconds:
                           format: int64
                           type: integer

--- a/config/crd/bases/cluster.ytsaurus.tech_remoteytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remoteytsaurus.yaml
@@ -760,11 +760,17 @@ spec:
                           format: int64
                           type: integer
                         maxSegmentSize:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         maxTotalSizeToKeep:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         rotationPeriodMilliseconds:
                           format: int64
                           type: integer
@@ -925,11 +931,17 @@ spec:
                           format: int64
                           type: integer
                         maxSegmentSize:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         maxTotalSizeToKeep:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         rotationPeriodMilliseconds:
                           format: int64
                           type: integer

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -874,11 +874,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -1043,11 +1049,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -3272,11 +3284,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -3448,11 +3466,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -5682,11 +5706,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -5851,11 +5881,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -8116,11 +8152,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -8266,11 +8308,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -8450,11 +8498,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -10704,11 +10758,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -10882,11 +10942,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -13154,11 +13220,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -13323,11 +13395,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -15600,11 +15678,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -15778,11 +15862,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -18000,11 +18090,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -18169,11 +18265,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -20389,11 +20491,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -20558,11 +20666,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -22785,11 +22899,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -22965,11 +23085,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -25217,11 +25343,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -25386,11 +25518,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -27621,11 +27759,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -27799,11 +27943,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -30090,11 +30240,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -30266,11 +30422,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -32506,11 +32668,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -32692,11 +32860,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -35134,11 +35308,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -35303,11 +35483,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer

--- a/docs/api.md
+++ b/docs/api.md
@@ -769,8 +769,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `rotationPeriodMilliseconds` _integer_ |  |  |  |
-| `maxSegmentSize` _integer_ |  |  |  |
-| `maxTotalSizeToKeep` _integer_ |  |  |  |
+| `maxSegmentSize` _[Quantity](#quantity)_ |  |  |  |
+| `maxTotalSizeToKeep` _[Quantity](#quantity)_ |  |  |  |
 | `maxSegmentCountToKeep` _integer_ |  |  |  |
 
 

--- a/pkg/ytconfig/generator_test.go
+++ b/pkg/ytconfig/generator_test.go
@@ -26,7 +26,7 @@ var (
 		Name:      testYtsaurusName,
 	}
 	testLogRotationPeriod   int64 = 900000
-	testTotalLogSize              = 10 * int64(1<<30)
+	testTotalLogSize              = resource.MustParse("10Gi")
 	testMasterExternalHosts       = []string{
 		"host1.external.address",
 		"host2.external.address",
@@ -675,7 +675,7 @@ func getDataNodeSpec(locations ...ytv1.LocationSpec) ytv1.DataNodesSpec {
 
 func getExecNodeSpec(jobResources *corev1.ResourceRequirements) ytv1.ExecNodesSpec {
 	rotationPolicyMS := int64(900000)
-	rotationPolicyMaxTotalSize := int64(3145728)
+	rotationPolicyMaxTotalSize := resource.MustParse("3145728")
 	return ytv1.ExecNodesSpec{
 		InstanceSpec: ytv1.InstanceSpec{
 			InstanceCount:  50,

--- a/pkg/ytconfig/logging.go
+++ b/pkg/ytconfig/logging.go
@@ -63,6 +63,13 @@ type LoggingRule struct {
 	Family            *LogFamily    `yson:"family,omitempty"`
 }
 
+type LogRotationPolicy struct {
+	RotationPeriodMilliseconds *int64 `yson:"rotation_period,omitempty"`
+	MaxSegmentSize             *int64 `yson:"max_segment_size,omitempty"`
+	MaxTotalSizeToKeep         *int64 `yson:"max_total_size_to_keep,omitempty"`
+	MaxSegmentCountToKeep      *int64 `yson:"max_segment_count_to_keep,omitempty"`
+}
+
 type LoggingWriter struct {
 	WriterType ytv1.LogWriterType `yson:"type,omitempty"`
 	FileName   string             `yson:"file_name,omitempty"`
@@ -73,7 +80,7 @@ type LoggingWriter struct {
 	UseTimestampSuffix   bool   `yson:"use_timestamp_suffix,omitempty"`
 	EnableSystemMessages bool   `yson:"enable_system_messages,omitempty"`
 
-	RotationPolicy *ytv1.LogRotationPolicy `yson:"rotation_policy,omitempty"`
+	RotationPolicy *LogRotationPolicy `yson:"rotation_policy,omitempty"`
 }
 
 type Logging struct {
@@ -171,7 +178,19 @@ func createBaseLoggingWriter(componentName string, loggingDirectory string, writ
 	}
 
 	loggingWriter.UseTimestampSuffix = loggerSpec.UseTimestampSuffix
-	loggingWriter.RotationPolicy = loggerSpec.RotationPolicy
+
+	if loggerSpec.RotationPolicy != nil {
+		loggingWriter.RotationPolicy = &LogRotationPolicy{
+			RotationPeriodMilliseconds: loggerSpec.RotationPolicy.RotationPeriodMilliseconds,
+			MaxSegmentCountToKeep:      loggerSpec.RotationPolicy.MaxSegmentCountToKeep,
+		}
+		if loggerSpec.RotationPolicy.MaxSegmentSize != nil {
+			loggingWriter.RotationPolicy.MaxSegmentSize = ptr.To(loggerSpec.RotationPolicy.MaxSegmentSize.Value())
+		}
+		if loggerSpec.RotationPolicy.MaxTotalSizeToKeep != nil {
+			loggingWriter.RotationPolicy.MaxTotalSizeToKeep = ptr.To(loggerSpec.RotationPolicy.MaxTotalSizeToKeep.Value())
+		}
+	}
 	return loggingWriter
 }
 

--- a/ytop-chart/templates/remoteexecnodes-crd.yaml
+++ b/ytop-chart/templates/remoteexecnodes-crd.yaml
@@ -816,11 +816,17 @@ spec:
                           format: int64
                           type: integer
                         maxSegmentSize:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         maxTotalSizeToKeep:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         rotationPeriodMilliseconds:
                           format: int64
                           type: integer
@@ -963,11 +969,17 @@ spec:
                           format: int64
                           type: integer
                         maxSegmentSize:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         maxTotalSizeToKeep:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         rotationPeriodMilliseconds:
                           format: int64
                           type: integer
@@ -1155,11 +1167,17 @@ spec:
                           format: int64
                           type: integer
                         maxSegmentSize:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         maxTotalSizeToKeep:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         rotationPeriodMilliseconds:
                           format: int64
                           type: integer

--- a/ytop-chart/templates/remoteytsaurus-crd.yaml
+++ b/ytop-chart/templates/remoteytsaurus-crd.yaml
@@ -744,11 +744,17 @@ spec:
                           format: int64
                           type: integer
                         maxSegmentSize:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         maxTotalSizeToKeep:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         rotationPeriodMilliseconds:
                           format: int64
                           type: integer
@@ -909,11 +915,17 @@ spec:
                           format: int64
                           type: integer
                         maxSegmentSize:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         maxTotalSizeToKeep:
-                          format: int64
-                          type: integer
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
                         rotationPeriodMilliseconds:
                           format: int64
                           type: integer

--- a/ytop-chart/templates/ytsaurus-crd.yaml
+++ b/ytop-chart/templates/ytsaurus-crd.yaml
@@ -884,11 +884,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -1052,11 +1058,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -3260,11 +3272,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -3436,11 +3454,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -5660,11 +5684,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -5828,11 +5858,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -8072,11 +8108,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -8222,11 +8264,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -8406,11 +8454,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -10647,11 +10701,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -10825,11 +10885,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -13087,11 +13153,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -13255,11 +13327,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -15514,11 +15592,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -15691,11 +15775,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -17895,11 +17985,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -18063,11 +18159,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -20265,11 +20367,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -20433,11 +20541,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -22639,11 +22753,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -22819,11 +22939,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -25061,11 +25187,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -25229,11 +25361,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -27443,11 +27581,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -27621,11 +27765,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -29899,11 +30049,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -30075,11 +30231,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -32302,11 +32464,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -32488,11 +32656,17 @@ spec:
                                 format: int64
                                 type: integer
                               maxSegmentSize:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               maxTotalSizeToKeep:
-                                format: int64
-                                type: integer
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               rotationPeriodMilliseconds:
                                 format: int64
                                 type: integer
@@ -34918,11 +35092,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer
@@ -35086,11 +35266,17 @@ spec:
                               format: int64
                               type: integer
                             maxSegmentSize:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             maxTotalSizeToKeep:
-                              format: int64
-                              type: integer
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             rotationPeriodMilliseconds:
                               format: int64
                               type: integer


### PR DESCRIPTION
The change is backwards compatible and allows to use suffixes (Ki, Mi, Gi).