### PR TITLE
Use `secure` instead of `useInsecureCookies`, pass caBundle to UI

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -479,6 +479,10 @@ type UISpec struct {
 	//+kubebuilder:default:=NodePort
 	ServiceType  corev1.ServiceType `json:"serviceType,omitempty"`
 	HttpNodePort *int32             `json:"httpNodePort,omitempty"`
+	// If defined allows insecure (over http) authentication.
+	// Deprecated: use `secure` instead.
+	//+optional
+	UseInsecureCookies *bool `json:"useInsecureCookies"`
 	// Use secure connection to the cluster's http-proxies.
 	//+kubebuilder:default:=false
 	//+optional

--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -479,11 +479,12 @@ type UISpec struct {
 	//+kubebuilder:default:=NodePort
 	ServiceType  corev1.ServiceType `json:"serviceType,omitempty"`
 	HttpNodePort *int32             `json:"httpNodePort,omitempty"`
-	//+kubebuilder:default:=true
+	// Use secure connection to the cluster's http-proxies.
+	//+kubebuilder:default:=false
 	//+optional
-	UseInsecureCookies bool                        `json:"useInsecureCookies"`
-	Resources          corev1.ResourceRequirements `json:"resources,omitempty"`
-	InstanceCount      int32                       `json:"instanceCount,omitempty"`
+	Secure        bool                        `json:"secure"`
+	Resources     corev1.ResourceRequirements `json:"resources,omitempty"`
+	InstanceCount int32                       `json:"instanceCount,omitempty"`
 
 	// If defined it will be used for direct heavy url/commands like: read_table, write_table, etc.
 	//+optional

--- a/api/v1/ytsaurus_webhook.go
+++ b/api/v1/ytsaurus_webhook.go
@@ -398,6 +398,26 @@ func (r *Ytsaurus) validateYQLAgents(*Ytsaurus) field.ErrorList {
 	return allErrors
 }
 
+func (r *Ytsaurus) validateUi(*Ytsaurus) field.ErrorList {
+	var allErrors field.ErrorList
+
+	if r.Spec.UI != nil && r.Spec.UI.Secure {
+		for i, hp := range r.Spec.HTTPProxies {
+			if hp.Role != consts.DefaultHTTPProxyRole {
+				continue
+			}
+			if hp.Transport.HTTPSSecret == nil {
+				allErrors = append(allErrors, field.Required(
+					field.NewPath("spec").Child("httpProxies").Index(i).Child("transport").Child("httpsSecret"),
+					fmt.Sprintf("configured HTTPS for proxy with `%s` role is required for ui.secure", consts.DefaultHTTPProxyRole)))
+			}
+			break
+		}
+	}
+
+	return allErrors
+}
+
 //////////////////////////////////////////////////
 
 func (r *Ytsaurus) validateInstanceSpec(instanceSpec InstanceSpec, path *field.Path) field.ErrorList {
@@ -446,6 +466,7 @@ func (r *Ytsaurus) validateYtsaurus(old *Ytsaurus) field.ErrorList {
 	allErrors = append(allErrors, r.validateQueueAgents(old)...)
 	allErrors = append(allErrors, r.validateSpyt(old)...)
 	allErrors = append(allErrors, r.validateYQLAgents(old)...)
+	allErrors = append(allErrors, r.validateUi(old)...)
 
 	return allErrors
 }

--- a/api/v1/ytsaurus_webhook.go
+++ b/api/v1/ytsaurus_webhook.go
@@ -401,17 +401,22 @@ func (r *Ytsaurus) validateYQLAgents(*Ytsaurus) field.ErrorList {
 func (r *Ytsaurus) validateUi(*Ytsaurus) field.ErrorList {
 	var allErrors field.ErrorList
 
-	if r.Spec.UI != nil && r.Spec.UI.Secure {
-		for i, hp := range r.Spec.HTTPProxies {
-			if hp.Role != consts.DefaultHTTPProxyRole {
-				continue
+	if r.Spec.UI != nil {
+		if r.Spec.UI.UseInsecureCookies != nil && !*r.Spec.UI.UseInsecureCookies && !r.Spec.UI.Secure {
+			allErrors = append(allErrors, field.Invalid(field.NewPath("spec", "ui", "useInsecureCookies"), r.Spec.UI.UseInsecureCookies, "useInsecureCookies is deprecated, use secure instead"))
+		}
+		if r.Spec.UI.Secure {
+			for i, hp := range r.Spec.HTTPProxies {
+				if hp.Role != consts.DefaultHTTPProxyRole {
+					continue
+				}
+				if hp.Transport.HTTPSSecret == nil {
+					allErrors = append(allErrors, field.Required(
+						field.NewPath("spec", "httpProxies").Index(i).Child("transport", "httpsSecret"),
+						fmt.Sprintf("configured HTTPS for proxy with `%s` role is required for ui.secure", consts.DefaultHTTPProxyRole)))
+				}
+				break
 			}
-			if hp.Transport.HTTPSSecret == nil {
-				allErrors = append(allErrors, field.Required(
-					field.NewPath("spec").Child("httpProxies").Index(i).Child("transport").Child("httpsSecret"),
-					fmt.Sprintf("configured HTTPS for proxy with `%s` role is required for ui.secure", consts.DefaultHTTPProxyRole)))
-			}
-			break
 		}
 	}
 

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -1479,6 +1479,11 @@ func (in *UISpec) DeepCopyInto(out *UISpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.UseInsecureCookies != nil {
+		in, out := &in.UseInsecureCookies, &out.UseInsecureCookies
+		*out = new(bool)
+		**out = **in
+	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	if in.ExternalProxy != nil {
 		in, out := &in.ExternalProxy, &out.ExternalProxy

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -34376,6 +34376,10 @@ spec:
                           resources required.
                         type: object
                     type: object
+                  secure:
+                    default: false
+                    description: Use secure connection to the cluster's http-proxies.
+                    type: boolean
                   serviceType:
                     default: NodePort
                     description: Service Type string describes ingress methods for
@@ -34384,9 +34388,6 @@ spec:
                   theme:
                     default: lavander
                     type: string
-                  useInsecureCookies:
-                    default: true
-                    type: boolean
                 type: object
               uiImage:
                 type: string

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -34388,6 +34388,9 @@ spec:
                   theme:
                     default: lavander
                     type: string
+                  useInsecureCookies:
+                    description: If defined allows insecure (over http) authentication.
+                    type: boolean
                 type: object
               uiImage:
                 type: string

--- a/docs/api.md
+++ b/docs/api.md
@@ -1541,6 +1541,7 @@ _Appears in:_
 | `image` _string_ |  |  |  |
 | `serviceType` _[ServiceType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#servicetype-v1-core)_ |  | NodePort |  |
 | `httpNodePort` _integer_ |  |  |  |
+| `useInsecureCookies` _boolean_ | If defined allows insecure (over http) authentication.<br />Deprecated: use `secure` instead. |  |  |
 | `secure` _boolean_ | Use secure connection to the cluster's http-proxies. | false |  |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ |  |  |  |
 | `instanceCount` _integer_ |  |  |  |

--- a/docs/api.md
+++ b/docs/api.md
@@ -1541,7 +1541,7 @@ _Appears in:_
 | `image` _string_ |  |  |  |
 | `serviceType` _[ServiceType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#servicetype-v1-core)_ |  | NodePort |  |
 | `httpNodePort` _integer_ |  |  |  |
-| `useInsecureCookies` _boolean_ |  | true |  |
+| `secure` _boolean_ | Use secure connection to the cluster's http-proxies. | false |  |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ |  |  |  |
 | `instanceCount` _integer_ |  |  |  |
 | `externalProxy` _string_ | If defined it will be used for direct heavy url/commands like: read_table, write_table, etc. |  |  |

--- a/pkg/ytconfig/canondata/TestGetUIClustersConfigWithSettings/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetUIClustersConfigWithSettings/test.canondata
@@ -5,7 +5,7 @@
             name=test;
             proxy="http-proxies-lb-test.fake.svc.fake.zone";
             externalProxy="https://my-external-proxy.example.com";
-            secure=%false;
+            secure=%true;
             authentication=basic;
             group="My YTsaurus clusters";
             theme="";

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -684,6 +684,7 @@ func (g *Generator) GetUIClustersConfig() ([]byte, error) {
 	c.ID = g.ytsaurus.Name
 	c.Name = g.ytsaurus.Name
 	c.Proxy = g.GetHTTPProxiesAddress(consts.DefaultHTTPProxyRole)
+	c.Secure = g.ytsaurus.Spec.UI.Secure
 	c.ExternalProxy = g.ytsaurus.Spec.UI.ExternalProxy
 	c.PrimaryMaster.CellTag = g.ytsaurus.Spec.PrimaryMasters.CellTag
 

--- a/pkg/ytconfig/generator_test.go
+++ b/pkg/ytconfig/generator_test.go
@@ -627,6 +627,7 @@ func withUICustom(ytsaurus *ytv1.Ytsaurus) *ytv1.Ytsaurus {
 	ytsaurus.Spec.UI = &ytv1.UISpec{
 		ExternalProxy: &externalProxy,
 		OdinBaseUrl:   &odinUrl,
+		Secure:        true,
 	}
 	return ytsaurus
 }

--- a/ytop-chart/templates/ytsaurus-crd.yaml
+++ b/ytop-chart/templates/ytsaurus-crd.yaml
@@ -34163,6 +34163,10 @@ spec:
                           resources required.
                         type: object
                     type: object
+                  secure:
+                    default: false
+                    description: Use secure connection to the cluster's http-proxies.
+                    type: boolean
                   serviceType:
                     default: NodePort
                     description: Service Type string describes ingress methods for a
@@ -34171,9 +34175,6 @@ spec:
                   theme:
                     default: lavander
                     type: string
-                  useInsecureCookies:
-                    default: true
-                    type: boolean
                 type: object
               uiImage:
                 type: string

--- a/ytop-chart/templates/ytsaurus-crd.yaml
+++ b/ytop-chart/templates/ytsaurus-crd.yaml
@@ -34175,6 +34175,9 @@ spec:
                   theme:
                     default: lavander
                     type: string
+                  useInsecureCookies:
+                    description: If defined allows insecure (over http) authentication.
+                    type: boolean
                 type: object
               uiImage:
                 type: string


### PR DESCRIPTION
This change allows to use HTTPS connection from the UI to the cluster's http-proxies.

1. `secure` option is passed to the UI config.
2. `caBundle` is passed to the UI pods.
3. The webhook validates the presence of `httpsSecret` for the default proxy in case of a secure connection. 