### PR TITLE
Revert "test: skip case broken for macos"

### DIFF
--- a/controllers/remotedatanodes_test.go
+++ b/controllers/remotedatanodes_test.go
@@ -1,5 +1,3 @@
-//go:build !darwin
-
 package controllers_test
 
 import (

--- a/controllers/remoteexecnodes_test.go
+++ b/controllers/remoteexecnodes_test.go
@@ -1,5 +1,3 @@
-//go:build !darwin
-
 package controllers_test
 
 import (

--- a/controllers/remotetabletnodes_test.go
+++ b/controllers/remotetabletnodes_test.go
@@ -1,5 +1,3 @@
-//go:build !darwin
-
 package controllers_test
 
 import (

--- a/controllers/ytsaurus_local_test.go
+++ b/controllers/ytsaurus_local_test.go
@@ -1,5 +1,3 @@
-//go:build !darwin
-
 package controllers_test
 
 import (


### PR DESCRIPTION
This reverts commit 79d9fc53f3785d5ea7d17dc46f40e4c1fa796593.


No reason to fix that before switching to ginkgo.
They are likely racy and works on linux just by luck.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
