### PR TITLE
controllers: cleanup component manager

### DIFF
--- a/controllers/update_flow_steps.go
+++ b/controllers/update_flow_steps.go
@@ -181,7 +181,7 @@ var flowConditions = map[ytv1.UpdateState]flowCondition{
 		return stepResultMarkUnsatisfied
 	},
 	ytv1.UpdateStateImpossibleToStart: func(ctx context.Context, ytsaurus *apiProxy.Ytsaurus, componentManager *ComponentManager) stepResultMark {
-		if !componentManager.needSync() || !ytsaurus.GetResource().Spec.EnableFullUpdate {
+		if componentManager.status.allReady || !ytsaurus.GetResource().Spec.EnableFullUpdate {
 			return stepResultMarkHappy
 		}
 		return stepResultMarkUnsatisfied
@@ -214,7 +214,7 @@ var flowConditions = map[ytv1.UpdateState]flowCondition{
 		return stepResultMarkUnsatisfied
 	},
 	ytv1.UpdateStateWaitingForPodsCreation: func(ctx context.Context, ytsaurus *apiProxy.Ytsaurus, componentManager *ComponentManager) stepResultMark {
-		if componentManager.allReadyOrUpdating() {
+		if componentManager.status.allReadyOrUpdating {
 			return stepResultMarkHappy
 		}
 		return stepResultMarkUnsatisfied

--- a/pkg/components/bundle_controller.go
+++ b/pkg/components/bundle_controller.go
@@ -54,7 +54,7 @@ func (bc *BundleController) doSync(ctx context.Context, dry bool) (ComponentStat
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(bc.ytsaurus.GetClusterState()) && bc.server.needUpdate() {
-		return SimpleStatus(SyncStatusNeedLocalUpdate), err
+		return SimpleStatus(SyncStatusNeedUpdate), err
 	}
 
 	if bc.ytsaurus.GetClusterState() == ytv1.ClusterStateUpdating {
@@ -67,11 +67,11 @@ func (bc *BundleController) doSync(ctx context.Context, dry bool) (ComponentStat
 		if !dry {
 			err = bc.doServerSync(ctx)
 		}
-		return WaitingStatus(SyncStatusPending, "components"), err
+		return ComponentStatusWaitingFor("components"), err
 	}
 
 	if !bc.server.arePodsReady(ctx) {
-		return WaitingStatus(SyncStatusBlocked, "pods"), err
+		return ComponentStatusBlockedBy("pods"), err
 	}
 
 	return SimpleStatus(SyncStatusReady), err

--- a/pkg/components/chyt.go
+++ b/pkg/components/chyt.go
@@ -137,7 +137,7 @@ func (c *Chyt) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	var err error
 
 	if c.ytsaurus.Status.State != ytv1.ClusterStateRunning {
-		return WaitingStatus(SyncStatusBlocked, "ytsaurus running"), err
+		return ComponentStatusBlockedBy("ytsaurus is not running"), err
 	}
 
 	// Create a user for chyt initialization.
@@ -150,7 +150,7 @@ func (c *Chyt) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 			err = c.secret.Sync(ctx)
 		}
 		c.chyt.GetResource().Status.ReleaseStatus = ytv1.ChytReleaseStatusCreatingUserSecret
-		return WaitingStatus(SyncStatusPending, c.secret.Name()), err
+		return ComponentStatusWaitingFor(c.secret.Name()), err
 	}
 
 	if !dry {
@@ -200,7 +200,7 @@ func (c *Chyt) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 
 	c.chyt.GetResource().Status.ReleaseStatus = ytv1.ChytReleaseStatusFinished
 
-	return SimpleStatus(SyncStatusReady), err
+	return ComponentStatusReady(), err
 }
 
 func (c *Chyt) Fetch(ctx context.Context) error {

--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -15,30 +15,59 @@ import (
 type SyncStatus string
 
 const (
-	SyncStatusBlocked         SyncStatus = "Blocked"
-	SyncStatusNeedLocalUpdate SyncStatus = "NeedLocalUpdate"
-	SyncStatusPending         SyncStatus = "Pending"
-	SyncStatusReady           SyncStatus = "Ready"
-	SyncStatusUpdating        SyncStatus = "Updating"
+	SyncStatusReady      SyncStatus = "Ready"      // Running, reconciliation is not required
+	SyncStatusBlocked    SyncStatus = "Blocked"    // Reconciliation is impossible
+	SyncStatusPending    SyncStatus = "Pending"    // Reconciliation is possible
+	SyncStatusNeedUpdate SyncStatus = "NeedUpdate" // Running, update is required
+	SyncStatusUpdating   SyncStatus = "Updating"   // Update in progress
 )
-
-func IsRunningStatus(status SyncStatus) bool {
-	return status == SyncStatusReady || status == SyncStatusNeedLocalUpdate
-}
 
 type ComponentStatus struct {
 	SyncStatus SyncStatus
 	Message    string
 }
 
-func NewComponentStatus(status SyncStatus, message string) ComponentStatus {
-	return ComponentStatus{status, message}
+func (cs ComponentStatus) IsRunning() bool {
+	return cs.SyncStatus == SyncStatusReady || cs.SyncStatus == SyncStatusNeedUpdate
 }
 
-func WaitingStatus(status SyncStatus, event string) ComponentStatus {
-	return ComponentStatus{status, fmt.Sprintf("Wait for %s", event)}
+func ComponentStatusReady() ComponentStatus {
+	return ComponentStatus{SyncStatusReady, "Ready"}
 }
 
+func ComponentStatusReadyAfter(message string) ComponentStatus {
+	return ComponentStatus{SyncStatusReady, message}
+}
+
+func ComponentStatusBlocked(message string) ComponentStatus {
+	return ComponentStatus{SyncStatusBlocked, message}
+}
+
+func ComponentStatusPending(message string) ComponentStatus {
+	return ComponentStatus{SyncStatusPending, message}
+}
+
+func ComponentStatusNeedUpdate(message string) ComponentStatus {
+	return ComponentStatus{SyncStatusNeedUpdate, message}
+}
+
+func ComponentStatusUpdating(message string) ComponentStatus {
+	return ComponentStatus{SyncStatusUpdating, message}
+}
+
+func ComponentStatusBlockedBy(cause string) ComponentStatus {
+	return ComponentStatus{SyncStatusBlocked, fmt.Sprintf("Blocked by %s", cause)}
+}
+
+func ComponentStatusWaitingFor(event string) ComponentStatus {
+	return ComponentStatus{SyncStatusPending, fmt.Sprintf("Waiting for %s", event)}
+}
+
+func ComponentStatusUpdateStep(part string) ComponentStatus {
+	return ComponentStatus{SyncStatusUpdating, fmt.Sprintf("Updating %s", part)}
+}
+
+// TODO(khlebnikov): Replace this stub with status with meaningful message.
 func SimpleStatus(status SyncStatus) ComponentStatus {
 	return ComponentStatus{status, string(status)}
 }

--- a/pkg/components/cypressproxy.go
+++ b/pkg/components/cypressproxy.go
@@ -50,7 +50,7 @@ func (cyp *CypressProxy) doSync(ctx context.Context, dry bool) (ComponentStatus,
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(cyp.ytsaurus.GetClusterState()) && cyp.server.needUpdate() {
-		return SimpleStatus(SyncStatusNeedLocalUpdate), err
+		return SimpleStatus(SyncStatusNeedUpdate), err
 	}
 
 	if cyp.ytsaurus.GetClusterState() == ytv1.ClusterStateUpdating {
@@ -63,14 +63,14 @@ func (cyp *CypressProxy) doSync(ctx context.Context, dry bool) (ComponentStatus,
 		if !dry {
 			err = cyp.doServerSync(ctx)
 		}
-		return WaitingStatus(SyncStatusPending, "components"), err
+		return ComponentStatusWaitingFor("components"), err
 	}
 
 	if !cyp.server.arePodsReady(ctx) {
-		return WaitingStatus(SyncStatusBlocked, "pods"), err
+		return ComponentStatusBlockedBy("pods"), err
 	}
 
-	return SimpleStatus(SyncStatusReady), err
+	return ComponentStatusReady(), err
 }
 
 func (cyp *CypressProxy) Status(ctx context.Context) (ComponentStatus, error) {

--- a/pkg/components/data_node_remote.go
+++ b/pkg/components/data_node_remote.go
@@ -60,14 +60,14 @@ func (n *RemoteDataNode) doSync(ctx context.Context, dry bool) (ComponentStatus,
 		if !dry {
 			err = n.server.Sync(ctx)
 		}
-		return WaitingStatus(SyncStatusPending, "components"), err
+		return ComponentStatusWaitingFor("components"), err
 	}
 
 	if !n.server.arePodsReady(ctx) {
-		return WaitingStatus(SyncStatusBlocked, "pods"), err
+		return ComponentStatusBlockedBy("pods"), err
 	}
 
-	return SimpleStatus(SyncStatusReady), err
+	return ComponentStatusReady(), err
 }
 
 func (n *RemoteDataNode) GetType() consts.ComponentType { return consts.DataNodeType }

--- a/pkg/components/discovery.go
+++ b/pkg/components/discovery.go
@@ -52,7 +52,7 @@ func (d *Discovery) doSync(ctx context.Context, dry bool) (ComponentStatus, erro
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(d.ytsaurus.GetClusterState()) && d.server.needUpdate() {
-		return SimpleStatus(SyncStatusNeedLocalUpdate), err
+		return SimpleStatus(SyncStatusNeedUpdate), err
 	}
 
 	if d.ytsaurus.GetClusterState() == ytv1.ClusterStateUpdating {
@@ -65,14 +65,14 @@ func (d *Discovery) doSync(ctx context.Context, dry bool) (ComponentStatus, erro
 		if !dry {
 			err = d.server.Sync(ctx)
 		}
-		return WaitingStatus(SyncStatusPending, "components"), err
+		return ComponentStatusWaitingFor("components"), err
 	}
 
 	if !d.server.arePodsReady(ctx) {
-		return WaitingStatus(SyncStatusBlocked, "pods"), err
+		return ComponentStatusBlockedBy("pods"), err
 	}
 
-	return SimpleStatus(SyncStatusReady), err
+	return ComponentStatusReady(), err
 }
 
 func (d *Discovery) Status(ctx context.Context) (ComponentStatus, error) {

--- a/pkg/components/exec_node.go
+++ b/pkg/components/exec_node.go
@@ -91,7 +91,7 @@ func (n *ExecNode) doSync(ctx context.Context, dry bool) (ComponentStatus, error
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(n.ytsaurus.GetClusterState()) && (n.server.needUpdate() || n.sidecarConfigNeedsReload()) {
-		return SimpleStatus(SyncStatusNeedLocalUpdate), err
+		return SimpleStatus(SyncStatusNeedUpdate), err
 	}
 
 	if n.ytsaurus.GetClusterState() == ytv1.ClusterStateUpdating {
@@ -104,8 +104,8 @@ func (n *ExecNode) doSync(ctx context.Context, dry bool) (ComponentStatus, error
 	if err != nil {
 		return masterStatus, err
 	}
-	if !IsRunningStatus(masterStatus.SyncStatus) {
-		return WaitingStatus(SyncStatusBlocked, n.master.GetFullName()), err
+	if !masterStatus.IsRunning() {
+		return ComponentStatusBlockedBy(n.master.GetFullName()), err
 	}
 
 	if LocalServerNeedSync(n.server, n.ytsaurus) {
@@ -113,10 +113,10 @@ func (n *ExecNode) doSync(ctx context.Context, dry bool) (ComponentStatus, error
 	}
 
 	if !n.server.arePodsReady(ctx) {
-		return WaitingStatus(SyncStatusBlocked, "pods"), err
+		return ComponentStatusBlockedBy("pods"), err
 	}
 
-	return SimpleStatus(SyncStatusReady), err
+	return ComponentStatusReady(), err
 }
 
 func (n *ExecNode) Status(ctx context.Context) (ComponentStatus, error) {

--- a/pkg/components/exec_node_base.go
+++ b/pkg/components/exec_node_base.go
@@ -186,11 +186,11 @@ func (n *baseExecNode) doSyncBase(ctx context.Context, dry bool) (ComponentStatu
 	if !dry {
 		err = n.doBuildBase()
 		if err != nil {
-			return WaitingStatus(SyncStatusBlocked, "cannot build exec node spec"), err
+			return ComponentStatusBlockedBy("cannot build exec node spec"), err
 		}
 		err = resources.Sync(ctx, n.server, n.sidecarConfig)
 	}
-	return WaitingStatus(SyncStatusPending, "components"), err
+	return ComponentStatusWaitingFor("components"), err
 }
 
 func (n *baseExecNode) sidecarConfigNeedsReload() bool {

--- a/pkg/components/exec_node_remote.go
+++ b/pkg/components/exec_node_remote.go
@@ -83,10 +83,10 @@ func (n *RemoteExecNode) doSync(ctx context.Context, dry bool) (ComponentStatus,
 	}
 
 	if !n.server.arePodsReady(ctx) {
-		return WaitingStatus(SyncStatusBlocked, "pods"), err
+		return ComponentStatusBlockedBy("pods"), err
 	}
 
-	return SimpleStatus(SyncStatusReady), err
+	return ComponentStatusReady(), err
 }
 
 func (n *RemoteExecNode) GetType() consts.ComponentType { return consts.ExecNodeType }

--- a/pkg/components/helpers.go
+++ b/pkg/components/helpers.go
@@ -169,14 +169,14 @@ func handleUpdatingClusterState(
 			if !dry {
 				err = removePods(ctx, server, cmpBase)
 			}
-			return ptr.To(WaitingStatus(SyncStatusUpdating, "pods removal")), err
+			return ptr.To(ComponentStatusUpdateStep("pods removal")), err
 		}
 
 		if ytsaurus.GetUpdateState() != ytv1.UpdateStateWaitingForPodsCreation {
-			return ptr.To(NewComponentStatus(SyncStatusReady, "Nothing to do now")), err
+			return ptr.To(ComponentStatusReady()), err
 		}
 	} else {
-		return ptr.To(NewComponentStatus(SyncStatusReady, "Not updating component")), err
+		return ptr.To(ComponentStatusReadyAfter("Not updating component")), err
 	}
 	return nil, err
 }

--- a/pkg/components/init_job.go
+++ b/pkg/components/init_job.go
@@ -194,12 +194,12 @@ func (j *InitJob) Sync(ctx context.Context, dry bool) (ComponentStatus, error) {
 			)
 		}
 
-		return WaitingStatus(SyncStatusPending, fmt.Sprintf("%s creation", j.initJob.Name())), err
+		return ComponentStatusWaitingFor(fmt.Sprintf("%s creation", j.initJob.Name())), err
 	}
 
 	if !j.initJob.Completed() {
 		logger.Info("Init job is not completed for " + j.labeller.GetFullComponentName())
-		return WaitingStatus(SyncStatusBlocked, fmt.Sprintf("%s completion", j.initJob.Name())), err
+		return ComponentStatusBlockedBy(fmt.Sprintf("%s completion", j.initJob.Name())), err
 	}
 
 	if !dry {
@@ -211,7 +211,7 @@ func (j *InitJob) Sync(ctx context.Context, dry bool) (ComponentStatus, error) {
 		})
 	}
 
-	return WaitingStatus(SyncStatusPending, fmt.Sprintf("setting %s condition", j.initCompletedCondition)), err
+	return ComponentStatusWaitingFor(fmt.Sprintf("setting %s condition", j.initCompletedCondition)), err
 }
 
 func (j *InitJob) prepareRestart(ctx context.Context, dry bool) error {

--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -410,7 +410,7 @@ func (m *Master) doSync(ctx context.Context, dry bool) (ComponentStatus, error) 
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(m.ytsaurus.GetClusterState()) && m.server.needUpdate() {
-		return SimpleStatus(SyncStatusNeedLocalUpdate), err
+		return SimpleStatus(SyncStatusNeedUpdate), err
 	}
 
 	if m.ytsaurus.GetClusterState() == ytv1.ClusterStateUpdating {
@@ -434,18 +434,18 @@ func (m *Master) doSync(ctx context.Context, dry bool) (ComponentStatus, error) 
 			}
 			err = m.sidecarSecrets.hydraPersistenceUploaderSecret.Sync(ctx)
 		}
-		return WaitingStatus(SyncStatusPending, m.sidecarSecrets.hydraPersistenceUploaderSecret.Name()), err
+		return ComponentStatusWaitingFor(m.sidecarSecrets.hydraPersistenceUploaderSecret.Name()), err
 	}
 
 	if m.NeedSync() {
 		if !dry {
 			err = m.doServerSync(ctx)
 		}
-		return WaitingStatus(SyncStatusPending, "components"), err
+		return ComponentStatusWaitingFor("components"), err
 	}
 
 	if !m.server.arePodsReady(ctx) {
-		return WaitingStatus(SyncStatusBlocked, "pods"), err
+		return ComponentStatusBlockedBy("pods"), err
 	}
 
 	return m.runInitPhaseJobs(ctx, dry)

--- a/pkg/components/master_caches.go
+++ b/pkg/components/master_caches.go
@@ -50,7 +50,7 @@ func (mc *MasterCache) doSync(ctx context.Context, dry bool) (ComponentStatus, e
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(mc.ytsaurus.GetClusterState()) && mc.server.needUpdate() {
-		return SimpleStatus(SyncStatusNeedLocalUpdate), err
+		return SimpleStatus(SyncStatusNeedUpdate), err
 	}
 
 	if mc.ytsaurus.GetClusterState() == ytv1.ClusterStateUpdating {
@@ -63,14 +63,14 @@ func (mc *MasterCache) doSync(ctx context.Context, dry bool) (ComponentStatus, e
 		if !dry {
 			err = mc.doServerSync(ctx)
 		}
-		return WaitingStatus(SyncStatusPending, "components"), err
+		return ComponentStatusWaitingFor("components"), err
 	}
 
 	if !mc.server.arePodsReady(ctx) {
-		return WaitingStatus(SyncStatusBlocked, "pods"), err
+		return ComponentStatusBlockedBy("pods"), err
 	}
 
-	return SimpleStatus(SyncStatusReady), err
+	return ComponentStatusReady(), err
 }
 
 func (mc *MasterCache) Status(ctx context.Context) (ComponentStatus, error) {

--- a/pkg/components/offshore_data_gateway.go
+++ b/pkg/components/offshore_data_gateway.go
@@ -59,11 +59,11 @@ func (p *OffshoreDataGateway) doSync(ctx context.Context, dry bool) (ComponentSt
 		if !dry {
 			err = p.server.Sync(ctx)
 		}
-		return WaitingStatus(SyncStatusPending, "components"), err
+		return ComponentStatusWaitingFor("components"), err
 	}
 
 	if !p.server.arePodsReady(ctx) {
-		return WaitingStatus(SyncStatusBlocked, "pods"), err
+		return ComponentStatusWaitingFor("pods"), err
 	}
 
 	return SimpleStatus(SyncStatusReady), err

--- a/pkg/components/spyt.go
+++ b/pkg/components/spyt.go
@@ -92,11 +92,11 @@ func (s *Spyt) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	var err error
 
 	if s.ytsaurus.Status.State != ytv1.ClusterStateRunning {
-		return WaitingStatus(SyncStatusBlocked, s.ytsaurus.GetName()), err
+		return ComponentStatusBlockedBy(s.ytsaurus.GetName()), err
 	}
 
 	if s.spyt.GetResource().Status.ReleaseStatus == ytv1.SpytReleaseStatusFinished {
-		return SimpleStatus(SyncStatusReady), err
+		return ComponentStatusReady(), err
 	}
 
 	// Create user for spyt initialization.
@@ -109,7 +109,7 @@ func (s *Spyt) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 			err = s.secret.Sync(ctx)
 		}
 		s.spyt.GetResource().Status.ReleaseStatus = ytv1.SpytReleaseStatusCreatingUserSecret
-		return WaitingStatus(SyncStatusPending, s.secret.Name()), err
+		return ComponentStatusWaitingFor(s.secret.Name()), err
 	}
 
 	if !dry {
@@ -150,7 +150,7 @@ func (s *Spyt) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 
 	s.spyt.GetResource().Status.ReleaseStatus = ytv1.SpytReleaseStatusFinished
 
-	return SimpleStatus(SyncStatusReady), nil
+	return ComponentStatusReady(), nil
 }
 
 func (s *Spyt) Fetch(ctx context.Context) error {

--- a/pkg/components/suite_test.go
+++ b/pkg/components/suite_test.go
@@ -45,7 +45,7 @@ func NewFakeComponent(name string, compType consts.ComponentType) *FakeComponent
 	return &FakeComponent{
 		name:     name,
 		compType: compType,
-		status:   SimpleStatus(SyncStatusReady),
+		status:   ComponentStatusReady(),
 	}
 }
 

--- a/pkg/components/tablet_node_remote.go
+++ b/pkg/components/tablet_node_remote.go
@@ -60,14 +60,14 @@ func (n *RemoteTabletNode) doSync(ctx context.Context, dry bool) (ComponentStatu
 		if !dry {
 			err = n.server.Sync(ctx)
 		}
-		return WaitingStatus(SyncStatusPending, "components"), err
+		return ComponentStatusWaitingFor("components"), err
 	}
 
 	if !n.server.arePodsReady(ctx) {
-		return WaitingStatus(SyncStatusBlocked, "pods"), err
+		return ComponentStatusBlockedBy("pods"), err
 	}
 
-	return SimpleStatus(SyncStatusReady), err
+	return ComponentStatusReady(), err
 }
 
 func (n *RemoteTabletNode) GetType() consts.ComponentType { return consts.TabletNodeType }

--- a/pkg/components/tablet_node_test.go
+++ b/pkg/components/tablet_node_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Tablet node test", func() {
 			Expect(err).Should(Succeed())
 			Expect(status.SyncStatus).Should(Equal(SyncStatusBlocked))
 
-			ytsaurusClient.SetStatus(SimpleStatus(SyncStatusReady))
+			ytsaurusClient.SetStatus(ComponentStatusReady())
 
 			status, err = tabletNode.Status(context.Background())
 			Expect(err).Should(Succeed())


### PR DESCRIPTION
     - split component manager construction and fetching status
     - cleanup and describe logic
     - cleanup components state helpers
    
    ComponentState:
    "Ready"      // Running, reconciliation is not required
    "Blocked"    // Reconciliation is impossible
    "Pending"    // Reconciliation is possible
    "NeedUpdate" // Running, update is required
    "Updating"   // Update in progress
    
    ComponentManagerStatus:
    allReady    (was !needSync)
    allRunning  (was !needInit)
    allReadyOrUpdating
    
    Update state machine uses these aggregates for making decisions,
    and performs actions according to update plan.