### PR TITLE
Set user job memory limit in exec node config

### DIFF
--- a/pkg/ytconfig/canondata/TestGetExecNodeConfig/with-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfig/with-job-resources/test.canondata
@@ -100,6 +100,12 @@
         "total_memory"=111669149696;
         "total_cpu"=119.000000;
         "node_dedicated_cpu"=20.000000;
+        "memory_limits"={
+            "user_jobs"={
+                type=static;
+                value=106300440576;
+            };
+        };
     };
     tags=[
         "rack:xn-a";

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-containers-with-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-containers-with-job-resources/test.canondata
@@ -100,6 +100,12 @@
         "total_memory"=111669149696;
         "total_cpu"=119.000000;
         "node_dedicated_cpu"=20.000000;
+        "memory_limits"={
+            "user_jobs"={
+                type=static;
+                value=106300440576;
+            };
+        };
     };
     tags=[
         "rack:xn-a";

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-crio-with-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-crio-with-job-resources/test.canondata
@@ -100,6 +100,12 @@
         "total_memory"=111669149696;
         "total_cpu"=119.000000;
         "node_dedicated_cpu"=20.000000;
+        "memory_limits"={
+            "user_jobs"={
+                type=static;
+                value=106300440576;
+            };
+        };
     };
     tags=[
         "rack:xn-a";

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/single-container-with-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/single-container-with-job-resources/test.canondata
@@ -100,6 +100,12 @@
         "total_memory"=111669149696;
         "total_cpu"=119.000000;
         "node_dedicated_cpu"=20.000000;
+        "memory_limits"={
+            "user_jobs"={
+                type=static;
+                value=106300440576;
+            };
+        };
     };
     tags=[
         "rack:xn-a";


### PR DESCRIPTION
User jobs must use only dedicated job resources if they are defined.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
