### PR TITLE
Support for HTTPS-only API

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -802,10 +802,12 @@ type BundleControllerSpec struct {
 }
 
 type ClusterFeatures struct {
-	// RPC proxy have "public_rpc" address. Required for separated internal/public TLS CA.
+	// RPC proxies have "public_rpc" address. Required for separated internal/public TLS CA.
 	RPCProxyHavePublicAddress bool `json:"rpcProxyHavePublicAddress,omitempty"`
-	// HTTP proxy have "chyt_http_server" and "chyt_https_server". Opens ports for access to chyt via HTTP proxy.
+	// HTTP proxies have "chyt_http_server" and "chyt_https_server". Opens ports for access to chyt via HTTP proxy.
 	HTTPProxyHaveChytAddress bool `json:"httpProxyHaveChytAddress,omitempty"`
+	// HTTP proxies have "https" address. Use HTTPS for all communications.
+	HTTPProxyHaveHTTPSAddress bool `json:"httpProxyHaveHttpsAddress,omitempty"`
 }
 
 // CommonSpec is a set of fields shared between `YtsaurusSpec` and `Remote*NodesSpec`.

--- a/config/crd/bases/cluster.ytsaurus.tech_offshoredatagateways.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_offshoredatagateways.yaml
@@ -762,10 +762,14 @@ spec:
               clusterFeatures:
                 properties:
                   httpProxyHaveChytAddress:
-                    description: HTTP proxy have "chyt_http_server" and "chyt_https_server".
+                    description: HTTP proxies have "chyt_http_server" and "chyt_https_server".
+                    type: boolean
+                  httpProxyHaveHttpsAddress:
+                    description: HTTP proxies have "https" address. Use HTTPS for
+                      all communications.
                     type: boolean
                   rpcProxyHavePublicAddress:
-                    description: RPC proxy have "public_rpc" address.
+                    description: RPC proxies have "public_rpc" address.
                     type: boolean
                 type: object
               configOverrides:

--- a/config/crd/bases/cluster.ytsaurus.tech_remotedatanodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remotedatanodes.yaml
@@ -760,10 +760,14 @@ spec:
               clusterFeatures:
                 properties:
                   httpProxyHaveChytAddress:
-                    description: HTTP proxy have "chyt_http_server" and "chyt_https_server".
+                    description: HTTP proxies have "chyt_http_server" and "chyt_https_server".
+                    type: boolean
+                  httpProxyHaveHttpsAddress:
+                    description: HTTP proxies have "https" address. Use HTTPS for
+                      all communications.
                     type: boolean
                   rpcProxyHavePublicAddress:
-                    description: RPC proxy have "public_rpc" address.
+                    description: RPC proxies have "public_rpc" address.
                     type: boolean
                 type: object
               configOverrides:

--- a/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
@@ -760,10 +760,14 @@ spec:
               clusterFeatures:
                 properties:
                   httpProxyHaveChytAddress:
-                    description: HTTP proxy have "chyt_http_server" and "chyt_https_server".
+                    description: HTTP proxies have "chyt_http_server" and "chyt_https_server".
+                    type: boolean
+                  httpProxyHaveHttpsAddress:
+                    description: HTTP proxies have "https" address. Use HTTPS for
+                      all communications.
                     type: boolean
                   rpcProxyHavePublicAddress:
-                    description: RPC proxy have "public_rpc" address.
+                    description: RPC proxies have "public_rpc" address.
                     type: boolean
                 type: object
               configOverrides:

--- a/config/crd/bases/cluster.ytsaurus.tech_remotetabletnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remotetabletnodes.yaml
@@ -760,10 +760,14 @@ spec:
               clusterFeatures:
                 properties:
                   httpProxyHaveChytAddress:
-                    description: HTTP proxy have "chyt_http_server" and "chyt_https_server".
+                    description: HTTP proxies have "chyt_http_server" and "chyt_https_server".
+                    type: boolean
+                  httpProxyHaveHttpsAddress:
+                    description: HTTP proxies have "https" address. Use HTTPS for
+                      all communications.
                     type: boolean
                   rpcProxyHavePublicAddress:
-                    description: RPC proxy have "public_rpc" address.
+                    description: RPC proxies have "public_rpc" address.
                     type: boolean
                 type: object
               configOverrides:

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -1989,10 +1989,14 @@ spec:
               clusterFeatures:
                 properties:
                   httpProxyHaveChytAddress:
-                    description: HTTP proxy have "chyt_http_server" and "chyt_https_server".
+                    description: HTTP proxies have "chyt_http_server" and "chyt_https_server".
+                    type: boolean
+                  httpProxyHaveHttpsAddress:
+                    description: HTTP proxies have "https" address. Use HTTPS for
+                      all communications.
                     type: boolean
                   rpcProxyHavePublicAddress:
-                    description: RPC proxy have "public_rpc" address.
+                    description: RPC proxies have "public_rpc" address.
                     type: boolean
                 type: object
               configOverrides:

--- a/docs/api.md
+++ b/docs/api.md
@@ -332,8 +332,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `rpcProxyHavePublicAddress` _boolean_ | RPC proxy have "public_rpc" address. Required for separated internal/public TLS CA. |  |  |
-| `httpProxyHaveChytAddress` _boolean_ | HTTP proxy have "chyt_http_server" and "chyt_https_server". Opens ports for access to chyt via HTTP proxy. |  |  |
+| `rpcProxyHavePublicAddress` _boolean_ | RPC proxies have "public_rpc" address. Required for separated internal/public TLS CA. |  |  |
+| `httpProxyHaveChytAddress` _boolean_ | HTTP proxies have "chyt_http_server" and "chyt_https_server". Opens ports for access to chyt via HTTP proxy. |  |  |
+| `httpProxyHaveHttpsAddress` _boolean_ | HTTP proxies have "https" address. Use HTTPS for all communications. |  |  |
 
 
 #### ClusterNodesSpec

--- a/pkg/testutil/spec_builders.go
+++ b/pkg/testutil/spec_builders.go
@@ -305,6 +305,8 @@ func (b *YtsaurusBuilder) WithHTTPSProxies(httpsCert string, httpsOnly bool) {
 	b.WithHTTPSProxy = true
 	b.WithHTTPSOnlyProxy = httpsOnly
 
+	b.Ytsaurus.Spec.ClusterFeatures.HTTPProxyHaveHTTPSAddress = true
+
 	b.Ytsaurus.Spec.CARootBundle = &ytv1.FileObjectReference{
 		Name: TestCARootBundleName,
 	}
@@ -358,6 +360,7 @@ func (b *YtsaurusBuilder) WithAllClusterFeatures() {
 	b.Ytsaurus.Spec.ClusterFeatures = &ytv1.ClusterFeatures{
 		RPCProxyHavePublicAddress: true,
 		HTTPProxyHaveChytAddress:  true,
+		HTTPProxyHaveHTTPSAddress: true,
 	}
 }
 

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -1757,7 +1757,10 @@ exec "$@"`
 				ytBuilder.WithYqlAgent()
 				ytBuilder.WithStrawberryController()
 
-				withHTTPSProxy(false)
+				// FIXME(khlebnikov): Workaround for bug in strawberry controller logging.
+				ytsaurus.Spec.StrawberryController.LogToStderr = true
+
+				withHTTPSProxy(true)
 
 				withRPCTLSProxy()
 

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap cluster-yt-strawberry-controller-init-job-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap cluster-yt-strawberry-controller-init-job-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   chyt-init-cluster.yson: |-
     {
-        proxy="http-proxies-lb.ytsaurus-components.svc.cluster.local";
+        proxy="https://http-proxies-lb.ytsaurus-components.svc.cluster.local";
         "strawberry_root"="//sys/strawberry";
         families=[
             chyt;

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-strawberry-controller-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-strawberry-controller-config.yaml
@@ -3,7 +3,7 @@ data:
   strawberry-controller.yson: |-
     {
         "location_proxies"=[
-            "http-proxies-lb.ytsaurus-components.svc.cluster.local";
+            "https://http-proxies-lb.ytsaurus-components.svc.cluster.local";
         ];
         strawberry={
             root="//sys/strawberry";
@@ -47,7 +47,7 @@ data:
         };
         "http_api_endpoint"=":80";
         "http_location_aliases"={
-            "http-proxies-lb.ytsaurus-components.svc.cluster.local"=[
+            "https://http-proxies-lb.ytsaurus-components.svc.cluster.local"=[
                 "test-ytsaurus";
             ];
         };

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-yql-agent-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-yql-agent-config.yaml
@@ -109,7 +109,7 @@ data:
                 "cluster_mapping"=[
                     {
                         name="test-ytsaurus";
-                        cluster="http-proxies.ytsaurus-components.svc.cluster.local";
+                        cluster="https://http-proxies.ytsaurus-components.svc.cluster.local";
                         default=%true;
                     };
                 ];
@@ -119,7 +119,7 @@ data:
             "mr_job_binary"="/usr/bin/mrjob";
             "udf_directory"="/usr/lib/yql";
             "additional_clusters"={
-                "test-ytsaurus"="http-proxies.ytsaurus-components.svc.cluster.local";
+                "test-ytsaurus"="https://http-proxies.ytsaurus-components.svc.cluster.local";
             };
             "default_cluster"="test-ytsaurus";
             "additional_system_libs"=[

--- a/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
@@ -13,6 +13,7 @@ spec:
     name: ytsaurus-dev-ca-root-bundle
   clusterFeatures:
     httpProxyHaveChytAddress: true
+    httpProxyHaveHttpsAddress: true
     rpcProxyHavePublicAddress: true
   configOverrides:
     name: test-overrides

--- a/test/webhooks/ytsaurus_webhooks_test.go
+++ b/test/webhooks/ytsaurus_webhooks_test.go
@@ -34,6 +34,13 @@ var _ = Describe("Test for Ytsaurus webhooks", func() {
 			ytsaurus = newYtsaurus()
 		})
 
+		It("Should not accept feature httpProxyHaveHttpsAddress without httpsSecret", func() {
+			ytsaurus.Spec.ClusterFeatures = &ytv1.ClusterFeatures{
+				HTTPProxyHaveHTTPSAddress: true,
+			}
+			Expect(k8sClient.Create(ctx, ytsaurus)).Should(MatchError(ContainSubstring("Cluster feature httpProxyHaveHttpsAddress requires HTTPS for all HTTP proxies")))
+		})
+
 		It("Should not accept a Ytsaurus resource without `default` http proxy role", func() {
 			ytsaurus.Spec.HTTPProxies = []ytv1.HTTPProxiesSpec{
 				{

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_offshoredatagateways.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_offshoredatagateways.yaml
@@ -767,10 +767,14 @@ spec:
               clusterFeatures:
                 properties:
                   httpProxyHaveChytAddress:
-                    description: HTTP proxy have "chyt_http_server" and "chyt_https_server".
+                    description: HTTP proxies have "chyt_http_server" and "chyt_https_server".
+                    type: boolean
+                  httpProxyHaveHttpsAddress:
+                    description: HTTP proxies have "https" address. Use HTTPS for
+                      all communications.
                     type: boolean
                   rpcProxyHavePublicAddress:
-                    description: RPC proxy have "public_rpc" address.
+                    description: RPC proxies have "public_rpc" address.
                     type: boolean
                 type: object
               configOverrides:

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotedatanodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotedatanodes.yaml
@@ -765,10 +765,14 @@ spec:
               clusterFeatures:
                 properties:
                   httpProxyHaveChytAddress:
-                    description: HTTP proxy have "chyt_http_server" and "chyt_https_server".
+                    description: HTTP proxies have "chyt_http_server" and "chyt_https_server".
+                    type: boolean
+                  httpProxyHaveHttpsAddress:
+                    description: HTTP proxies have "https" address. Use HTTPS for
+                      all communications.
                     type: boolean
                   rpcProxyHavePublicAddress:
-                    description: RPC proxy have "public_rpc" address.
+                    description: RPC proxies have "public_rpc" address.
                     type: boolean
                 type: object
               configOverrides:

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remoteexecnodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remoteexecnodes.yaml
@@ -765,10 +765,14 @@ spec:
               clusterFeatures:
                 properties:
                   httpProxyHaveChytAddress:
-                    description: HTTP proxy have "chyt_http_server" and "chyt_https_server".
+                    description: HTTP proxies have "chyt_http_server" and "chyt_https_server".
+                    type: boolean
+                  httpProxyHaveHttpsAddress:
+                    description: HTTP proxies have "https" address. Use HTTPS for
+                      all communications.
                     type: boolean
                   rpcProxyHavePublicAddress:
-                    description: RPC proxy have "public_rpc" address.
+                    description: RPC proxies have "public_rpc" address.
                     type: boolean
                 type: object
               configOverrides:

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotetabletnodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotetabletnodes.yaml
@@ -765,10 +765,14 @@ spec:
               clusterFeatures:
                 properties:
                   httpProxyHaveChytAddress:
-                    description: HTTP proxy have "chyt_http_server" and "chyt_https_server".
+                    description: HTTP proxies have "chyt_http_server" and "chyt_https_server".
+                    type: boolean
+                  httpProxyHaveHttpsAddress:
+                    description: HTTP proxies have "https" address. Use HTTPS for
+                      all communications.
                     type: boolean
                   rpcProxyHavePublicAddress:
-                    description: RPC proxy have "public_rpc" address.
+                    description: RPC proxies have "public_rpc" address.
                     type: boolean
                 type: object
               configOverrides:

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -1994,10 +1994,14 @@ spec:
               clusterFeatures:
                 properties:
                   httpProxyHaveChytAddress:
-                    description: HTTP proxy have "chyt_http_server" and "chyt_https_server".
+                    description: HTTP proxies have "chyt_http_server" and "chyt_https_server".
+                    type: boolean
+                  httpProxyHaveHttpsAddress:
+                    description: HTTP proxies have "https" address. Use HTTPS for
+                      all communications.
                     type: boolean
                   rpcProxyHavePublicAddress:
-                    description: RPC proxy have "public_rpc" address.
+                    description: RPC proxies have "public_rpc" address.
                     type: boolean
                 type: object
               configOverrides:


### PR DESCRIPTION
- **Add cluster feature flag httpProxyHaveHttpsAddress**

This flag signals than HTTP API supports HTTPS and could be HTTPS-only.
    
When httpProxyHaveHttpsAddress is true operator will include "https://" schema into cluster YT_PROXY reference.

Closes: #285
