### PR TITLE
test/e2e: increase yt client log level to info

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -100,7 +100,9 @@ func setLogger() {
 		),
 	)
 	logf.SetLogger(zapr.NewLogger(logger))
-	ytLogger = &logy.Logger{L: logger}
+	ytLogger = &logy.Logger{
+		L: logger.WithOptions(zap.IncreaseLevel(zap.InfoLevel)),
+	}
 }
 
 var _ = SynchronizedBeforeSuite(func(ctx context.Context) []byte {


### PR DESCRIPTION
It is too verbose, especially operation waiting.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
