### PR TITLE
Add feature flag to secure cluster connections

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -814,6 +814,8 @@ type ClusterFeatures struct {
 	HTTPProxyHaveChytAddress bool `json:"httpProxyHaveChytAddress,omitempty"`
 	// HTTP proxies have "https" address. Use HTTPS for all communications.
 	HTTPProxyHaveHTTPSAddress bool `json:"httpProxyHaveHttpsAddress,omitempty"`
+	// Validate that only secure transports are allowed for cluster connections.
+	SecureClusterTransports bool `json:"secureClusterTransports,omitempty"`
 }
 
 // CommonSpec is a set of fields shared between `YtsaurusSpec` and `Remote*NodesSpec`.

--- a/config/crd/bases/cluster.ytsaurus.tech_offshoredatagateways.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_offshoredatagateways.yaml
@@ -817,6 +817,10 @@ spec:
                   rpcProxyHavePublicAddress:
                     description: RPC proxies have "public_rpc" address.
                     type: boolean
+                  secureClusterTransports:
+                    description: Validate that only secure transports are allowed
+                      for cluster connections.
+                    type: boolean
                 type: object
               configOverrides:
                 description: LocalObjectReference contains enough information to let

--- a/config/crd/bases/cluster.ytsaurus.tech_remotedatanodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remotedatanodes.yaml
@@ -815,6 +815,10 @@ spec:
                   rpcProxyHavePublicAddress:
                     description: RPC proxies have "public_rpc" address.
                     type: boolean
+                  secureClusterTransports:
+                    description: Validate that only secure transports are allowed
+                      for cluster connections.
+                    type: boolean
                 type: object
               configOverrides:
                 description: LocalObjectReference contains enough information to let

--- a/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
@@ -815,6 +815,10 @@ spec:
                   rpcProxyHavePublicAddress:
                     description: RPC proxies have "public_rpc" address.
                     type: boolean
+                  secureClusterTransports:
+                    description: Validate that only secure transports are allowed
+                      for cluster connections.
+                    type: boolean
                 type: object
               configOverrides:
                 description: LocalObjectReference contains enough information to let

--- a/config/crd/bases/cluster.ytsaurus.tech_remotetabletnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remotetabletnodes.yaml
@@ -815,6 +815,10 @@ spec:
                   rpcProxyHavePublicAddress:
                     description: RPC proxies have "public_rpc" address.
                     type: boolean
+                  secureClusterTransports:
+                    description: Validate that only secure transports are allowed
+                      for cluster connections.
+                    type: boolean
                 type: object
               configOverrides:
                 description: LocalObjectReference contains enough information to let

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -2044,6 +2044,10 @@ spec:
                   rpcProxyHavePublicAddress:
                     description: RPC proxies have "public_rpc" address.
                     type: boolean
+                  secureClusterTransports:
+                    description: Validate that only secure transports are allowed
+                      for cluster connections.
+                    type: boolean
                 type: object
               configOverrides:
                 description: LocalObjectReference contains enough information to let

--- a/config/crd/schema/cluster.ytsaurus.tech_offshoredatagateways_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_offshoredatagateways_v1.json
@@ -887,6 +887,10 @@
             "rpcProxyHavePublicAddress": {
               "description": "RPC proxies have \"public_rpc\" address.",
               "type": "boolean"
+            },
+            "secureClusterTransports": {
+              "description": "Validate that only secure transports are allowed for cluster connections.",
+              "type": "boolean"
             }
           }
         },

--- a/config/crd/schema/cluster.ytsaurus.tech_remotedatanodes_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_remotedatanodes_v1.json
@@ -887,6 +887,10 @@
             "rpcProxyHavePublicAddress": {
               "description": "RPC proxies have \"public_rpc\" address.",
               "type": "boolean"
+            },
+            "secureClusterTransports": {
+              "description": "Validate that only secure transports are allowed for cluster connections.",
+              "type": "boolean"
             }
           }
         },

--- a/config/crd/schema/cluster.ytsaurus.tech_remoteexecnodes_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_remoteexecnodes_v1.json
@@ -887,6 +887,10 @@
             "rpcProxyHavePublicAddress": {
               "description": "RPC proxies have \"public_rpc\" address.",
               "type": "boolean"
+            },
+            "secureClusterTransports": {
+              "description": "Validate that only secure transports are allowed for cluster connections.",
+              "type": "boolean"
             }
           }
         },

--- a/config/crd/schema/cluster.ytsaurus.tech_remotetabletnodes_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_remotetabletnodes_v1.json
@@ -887,6 +887,10 @@
             "rpcProxyHavePublicAddress": {
               "description": "RPC proxies have \"public_rpc\" address.",
               "type": "boolean"
+            },
+            "secureClusterTransports": {
+              "description": "Validate that only secure transports are allowed for cluster connections.",
+              "type": "boolean"
             }
           }
         },

--- a/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
@@ -2355,6 +2355,10 @@
             "rpcProxyHavePublicAddress": {
               "description": "RPC proxies have \"public_rpc\" address.",
               "type": "boolean"
+            },
+            "secureClusterTransports": {
+              "description": "Validate that only secure transports are allowed for cluster connections.",
+              "type": "boolean"
             }
           }
         },

--- a/docs/api.md
+++ b/docs/api.md
@@ -334,6 +334,7 @@ _Appears in:_
 | `rpcProxyHavePublicAddress` _boolean_ | RPC proxies have "public_rpc" address. Required for separated internal/public TLS CA. |  |  |
 | `httpProxyHaveChytAddress` _boolean_ | HTTP proxies have "chyt_http_server" and "chyt_https_server". Opens ports for access to chyt via HTTP proxy. |  |  |
 | `httpProxyHaveHttpsAddress` _boolean_ | HTTP proxies have "https" address. Use HTTPS for all communications. |  |  |
+| `secureClusterTransports` _boolean_ | Validate that only secure transports are allowed for cluster connections. |  |  |
 
 
 #### ClusterNodesSpec

--- a/pkg/testutil/spec_builders.go
+++ b/pkg/testutil/spec_builders.go
@@ -402,6 +402,7 @@ func (b *YtsaurusBuilder) WithAllClusterFeatures() {
 		RPCProxyHavePublicAddress: true,
 		HTTPProxyHaveChytAddress:  true,
 		HTTPProxyHaveHTTPSAddress: true,
+		SecureClusterTransports:   false, // Turned off to increase coverage.
 	}
 }
 

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_offshoredatagateways.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_offshoredatagateways.yaml
@@ -822,6 +822,10 @@ spec:
                   rpcProxyHavePublicAddress:
                     description: RPC proxies have "public_rpc" address.
                     type: boolean
+                  secureClusterTransports:
+                    description: Validate that only secure transports are allowed
+                      for cluster connections.
+                    type: boolean
                 type: object
               configOverrides:
                 description: LocalObjectReference contains enough information to let

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotedatanodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotedatanodes.yaml
@@ -820,6 +820,10 @@ spec:
                   rpcProxyHavePublicAddress:
                     description: RPC proxies have "public_rpc" address.
                     type: boolean
+                  secureClusterTransports:
+                    description: Validate that only secure transports are allowed
+                      for cluster connections.
+                    type: boolean
                 type: object
               configOverrides:
                 description: LocalObjectReference contains enough information to let

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remoteexecnodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remoteexecnodes.yaml
@@ -820,6 +820,10 @@ spec:
                   rpcProxyHavePublicAddress:
                     description: RPC proxies have "public_rpc" address.
                     type: boolean
+                  secureClusterTransports:
+                    description: Validate that only secure transports are allowed
+                      for cluster connections.
+                    type: boolean
                 type: object
               configOverrides:
                 description: LocalObjectReference contains enough information to let

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotetabletnodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotetabletnodes.yaml
@@ -820,6 +820,10 @@ spec:
                   rpcProxyHavePublicAddress:
                     description: RPC proxies have "public_rpc" address.
                     type: boolean
+                  secureClusterTransports:
+                    description: Validate that only secure transports are allowed
+                      for cluster connections.
+                    type: boolean
                 type: object
               configOverrides:
                 description: LocalObjectReference contains enough information to let

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -2049,6 +2049,10 @@ spec:
                   rpcProxyHavePublicAddress:
                     description: RPC proxies have "public_rpc" address.
                     type: boolean
+                  secureClusterTransports:
+                    description: Validate that only secure transports are allowed
+                      for cluster connections.
+                    type: boolean
                 type: object
               configOverrides:
                 description: LocalObjectReference contains enough information to let


### PR DESCRIPTION
This feature allows to validate that only secure transports are allowed:
- mTLS for native transport
- HTTPS-only HTTP proxies
- TLS-only RPC proxies

One feature to rule them all. It has effect only during spec validation.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
