### PR TITLE
Add forgotten prometheus_cluster_role.yaml for prometheus integration

### DIFF
--- a/config/samples/prometheus/prometheus_cluster_role.yaml
+++ b/config/samples/prometheus/prometheus_cluster_role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/metrics
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Without adding this cluster role it is not possible to apply role binding

See instruction example: https://coralogix.com/guides/prometheus-monitoring/prometheus-operator-basics-quick-tutorial/