### PR TITLE
Refactor YTsaurus test images

### DIFF
--- a/.github/workflows/subflow_run_e2e_tests.yaml
+++ b/.github/workflows/subflow_run_e2e_tests.yaml
@@ -7,6 +7,10 @@ on:
         type: string
         required: false
         default: ""
+      TEST_YTSAURUS_VERSION:
+        type: string
+        required: false
+        default: ""
 
   workflow_dispatch:
     inputs:
@@ -15,6 +19,14 @@ on:
         type: string
         required: false
         default: ""
+      TEST_YTSAURUS_VERSION:
+        description: "YTsaurus version or epoch"
+        type: string
+        required: false
+        default: ""
+
+env:
+  TEST_YTSAURUS_VERSION: "${{ inputs.TEST_YTSAURUS_VERSION }}"
 
 jobs:
   check:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,13 @@ on:
 
   pull_request: {}
 
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      TEST_YTSAURUS_VERSION:
+        description: "YTsaurus version or epoch"
+        type: string
+        required: false
+        default: ""
 
 jobs:
   check-unit:
@@ -17,6 +23,8 @@ jobs:
   check-e2e:
     name: Run e2e tests
     uses: ./.github/workflows/subflow_run_e2e_tests.yaml
+    with:
+      TEST_YTSAURUS_VERSION: "${{ inputs.TEST_YTSAURUS_VERSION }}"
 
   check-compat:
     name: Run compat tests

--- a/Makefile
+++ b/Makefile
@@ -440,6 +440,9 @@ helm-chart: manifests ## Generate helm chart.
 	go run ./hack/helm-crds.go $(OPERATOR_CHART_CRDS)/ config/crd/bases/*.yaml
 	$(YQ) '.name="$(OPERATOR_CHART_NAME_RELEASE)" | .version="$(OPERATOR_VERSION)" | .appVersion="$(OPERATOR_VERSION)"' <config/helm/Chart.yaml >$(OPERATOR_CHART)/Chart.yaml
 
+update-samples-image:
+	sed "s#$(firstword $(subst :, ,$(YTSAURUS_SAMPLE_IMAGE_CURRENT))):.*#${YTSAURUS_SAMPLE_IMAGE_CURRENT}#" -i config/samples/*.yaml
+
 ##@ Deployment
 
 ifndef ignore-not-found

--- a/config/samples/cluster_v1_cri.yaml
+++ b/config/samples/cluster_v1_cri.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   # https://ytsaurus.tech/docs/en/admin-guide/releases#ytsaurus-server
   # https://github.com/ytsaurus/ytsaurus/pkgs/container/ytsaurus
-  coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.1.0-relwithdebinfo
+  coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.2-relwithdebinfo
 
   # Default "docker_image" for jobs
   jobImage: mirror.gcr.io/library/python:3.12-slim

--- a/config/samples/cluster_v1_demo.yaml
+++ b/config/samples/cluster_v1_demo.yaml
@@ -5,7 +5,7 @@ kind: Ytsaurus
 metadata:
   name: ytdemo
 spec:
-  coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.1-relwithdebinfo
+  coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.2-relwithdebinfo
   uiImage: ghcr.io/ytsaurus/ui:stable
 
   adminCredentials:

--- a/config/samples/cluster_v1_local.yaml
+++ b/config/samples/cluster_v1_local.yaml
@@ -5,7 +5,7 @@ kind: Ytsaurus
 metadata:
   name: minisaurus
 spec:
-  coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.1-relwithdebinfo
+  coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.2-relwithdebinfo
 
   discovery:
     instanceCount: 1

--- a/config/samples/cluster_v1_remoteexecnodes.yaml
+++ b/config/samples/cluster_v1_remoteexecnodes.yaml
@@ -9,7 +9,7 @@ spec:
     name: remote-ytsaurus
 
   # FIXME: Move cluster options into RemoteYtsaurus.
-  coreImage: ghcr.io/ytsaurus/ytsaurus:dev-23.2-relwithdebinfo
+  coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.2-relwithdebinfo
 
   jobImage: mirror.gcr.io/library/python:3.12-slim
 

--- a/config/samples/cluster_v1_tls.yaml
+++ b/config/samples/cluster_v1_tls.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   # https://ytsaurus.tech/docs/en/admin-guide/releases#ytsaurus-server
   # https://github.com/ytsaurus/ytsaurus/pkgs/container/ytsaurus
-  coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.1.0-relwithdebinfo
+  coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.2-relwithdebinfo
 
   # Default "docker_image" for jobs
   jobImage: mirror.gcr.io/library/python:3.12-slim

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+	"regexp"
 
 	"runtime/debug"
 
@@ -13,6 +14,10 @@ var version string
 
 const (
 	DevelVersion = "0.0.0-devel"
+)
+
+var (
+	ytsaurusVersionPrefix = regexp.MustCompile(`^[a-z]+-`)
 )
 
 func GetVersion() string {
@@ -41,6 +46,10 @@ func ParseVersion(version string) (*Version, error) {
 	return semver.NewVersion(version)
 }
 
+func MustParse(version string) *Version {
+	return semver.MustParse(version)
+}
+
 type Constraints = semver.Constraints
 
 func ParseConstraints(constraints string) (*Constraints, error) {
@@ -59,4 +68,9 @@ func GetParsedVersion() *Version {
 		ver = semver.New(0, 0, 0, "malformed", version)
 	}
 	return ver
+}
+
+func ParseYtsaurusVersion(version string) (*Version, error) {
+	version = ytsaurusVersionPrefix.ReplaceAllString(version, "")
+	return ParseVersion(version)
 }

--- a/test-env.inc
+++ b/test-env.inc
@@ -1,70 +1,115 @@
 # vim: set filetype=make :
 
+export YTSAURUS_JOB_IMAGE ?= mirror.gcr.io/library/python:3.12-slim
+
 # https://ytsaurus.tech/docs/en/admin-guide/releases
 
-YTSAURUS_REGISTRY = ghcr.io/ytsaurus
+## Ytsaurus registry
+YTSAURUS_REGISTRY ?= ghcr.io/ytsaurus
+export YTSAURUS_REGISTRY
 
-# options for e2e tests
+# options for e2e tests:
+# epoch := PAST, PREVIOUS, CURRENT, COMING, FUTURE, NIGHTLY, <version>
+# version := ${<name>_VERSION_<epoch>} or <epoch>
+# image := ${<name>_IMAGE_<version>} or ${<name>_IMAGE}:<version> or ${YTSAURUS_REGISTRY}/<name>:<version>
 
 # https://github.com/ytsaurus/ytsaurus/pkgs/container/ytsaurus
 # https://github.com/ytsaurus/ytsaurus/pkgs/container/ytsaurus-nightly
 # skopeo inspect --format '{{range .RepoTags}}{{.}}\n{{end -}}' docker://ghcr.io/ytsaurus/ytsaurus-nightly
 
-export YTSAURUS_IMAGE_23_2 = ${YTSAURUS_REGISTRY}/ytsaurus:stable-23.2.0
-# export YTSAURUS_IMAGE_23_2 = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-23.2-2025-02-19-7dae008dd5171a9c89857f2034746ac3119842db
+## ytsaurus version or epoch for tests: X.Y[.Z], PAST, PREVIOUS, CURRENT, COMING, FUTURE, NIGHTLY
+TEST_YTSAURUS_VERSION ?= CURRENT
+export TEST_YTSAURUS_VERSION
 
-export YTSAURUS_IMAGE_24_1 = ${YTSAURUS_REGISTRY}/ytsaurus:stable-24.1.0
-# export YTSAURUS_IMAGE_24_1 = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-24.1-2025-06-18-dd4bd8bdc4d28993e7185b820930761540b29ae9
+export YTSAURUS_IMAGE ?= ${YTSAURUS_REGISTRY}/ytsaurus
 
-export YTSAURUS_IMAGE_24_2 = ${YTSAURUS_REGISTRY}/ytsaurus:stable-24.2.1
-# export YTSAURUS_IMAGE_24_2 = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-24.2-2025-07-28-567fa5b92fd448f708f84f7755dacf4560810ef6
+## ytsaurus past version
+YTSAURUS_VERSION_PAST ?= 23.2.0
+export YTSAURUS_VERSION_PAST
 
-export YTSAURUS_IMAGE_25_1 = ${YTSAURUS_REGISTRY}/ytsaurus:stable-25.1.0
-# export YTSAURUS_IMAGE_25_1 = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-25.1-2025-07-28-b75342ada631c8d78b95c29c4de46225c877f1d2
+## ytsaurus previous version
+YTSAURUS_VERSION_PREVIOUS ?= 24.1.0
+export YTSAURUS_VERSION_PREVIOUS
 
-export YTSAURUS_IMAGE_25_2 = ${YTSAURUS_REGISTRY}/ytsaurus:stable-25.2.1
-# export YTSAURUS_IMAGE_25_2 = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-25.2-2025-09-24-8779082dedb3ca96c30a5cba04dd4d3b9f05fa90
+## ytsaurus current version
+YTSAURUS_VERSION_CURRENT ?= 24.2.1
+export YTSAURUS_VERSION_CURRENT
 
-export YTSAURUS_IMAGE_PREVIOUS = ${YTSAURUS_IMAGE_24_1}
-export YTSAURUS_IMAGE_CURRENT = ${YTSAURUS_IMAGE_24_2}
-export YTSAURUS_IMAGE_FUTURE = ${YTSAURUS_IMAGE_25_2}
-export YTSAURUS_IMAGE_NIGHTLY = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-2025-11-11-1ea9f902e888db24630cdef436de8348b433ac4f
+## ytsaurus coming version
+YTSAURUS_VERSION_COMING ?= 25.1.0
+export YTSAURUS_VERSION_COMING
+
+## ytsaurus future version
+YTSAURUS_VERSION_FUTURE ?= 25.2.2
+export YTSAURUS_VERSION_FUTURE
+
+## ytsaurus nightly version
+YTSAURUS_VERSION_NIGHTLY ?= 26.1.99
+export YTSAURUS_VERSION_NIGHTLY
+
+export YTSAURUS_IMAGE_23_2_99 ?= ${YTSAURUS_IMAGE}-nightly:dev-23.2-2025-02-19-7dae008dd5171a9c89857f2034746ac3119842db
+export YTSAURUS_IMAGE_24_1_99 ?= ${YTSAURUS_IMAGE}-nightly:dev-24.1-2025-06-18-dd4bd8bdc4d28993e7185b820930761540b29ae9
+export YTSAURUS_IMAGE_24_2_99 ?= ${YTSAURUS_IMAGE}-nightly:dev-24.2-2025-09-05-522db86a58d4950019121180a35c9b56d0d8af76
+export YTSAURUS_IMAGE_25_1_99 ?= ${YTSAURUS_IMAGE}-nightly:dev-25.1-2025-09-30-da1f6800979c77f5a19f44dc18d970bb5a70ac03
+export YTSAURUS_IMAGE_25_2_99 ?= ${YTSAURUS_IMAGE}-nightly:dev-25.2-2025-12-09-d1b3fc19add6314e39833c19ebb8487f2f734ff9
+export YTSAURUS_IMAGE_25_3_99 ?= ${YTSAURUS_IMAGE}-nightly:dev-25.3-2026-01-29-e13f47bfc34bcd70e6b268e0e3778366606e059e
+export YTSAURUS_IMAGE_25_4_99 ?= ${YTSAURUS_IMAGE}-nightly:dev-25.4-2026-01-30-337b71eda802fd46fb01780fbfe2d7a1ba757b25
+export YTSAURUS_IMAGE_26_1_99 ?= ${YTSAURUS_IMAGE}-nightly:dev-2026-01-30-20d7d021364a7e544a8ea59c22f058e0f13f0d94
 
 # https://github.com/ytsaurus/ytsaurus/pkgs/container/query-tracker
 # https://github.com/ytsaurus/ytsaurus/pkgs/container/query-tracker-nightly
 # skopeo inspect --format '{{range .RepoTags}}{{.}}\n{{end -}}' docker://ghcr.io/ytsaurus/query-tracker-nightly:dev-2025-07-23-be855609d82ae5c6952a6b5c8c4e1706d1b18232
-export QUERY_TRACKER_IMAGE_PREVIOUS = ${YTSAURUS_REGISTRY}/query-tracker:0.0.10
-export QUERY_TRACKER_IMAGE_CURRENT = ${YTSAURUS_REGISTRY}/query-tracker:0.0.11
-export QUERY_TRACKER_IMAGE_FUTURE = ${YTSAURUS_REGISTRY}/query-tracker:0.0.11
-export QUERY_TRACKER_IMAGE_NIGHTLY = ${YTSAURUS_REGISTRY}/query-tracker-nightly:dev-2025-11-11-1ea9f902e888db24630cdef436de8348b433ac4f
+
+export QUERY_TRACKER_IMAGE ?= ${YTSAURUS_REGISTRY}/query-tracker
+
+export QUERY_TRACKER_VERSION_PAST ?= 0.0.10
+export QUERY_TRACKER_VERSION_PREVIOUS ?= 0.0.10
+export QUERY_TRACKER_VERSION_CURRENT ?= 0.0.11
+export QUERY_TRACKER_VERSION_COMING ?= 0.0.11
+export QUERY_TRACKER_VERSION_FUTURE ?= 0.1.2
+
+export QUERY_TRACKER_IMAGE_0_1_2 ?= ${QUERY_TRACKER_IMAGE}:stable-0.1.2
+
+export QUERY_TRACKER_IMAGE_NIGHTLY ?= ${QUERY_TRACKER_IMAGE}-nightly:dev-2026-01-30-14313a1279bd3f096e4d621722d06f4dd511ce98
 
 # https://github.com/ytsaurus/ytsaurus/pkgs/container/strawberry
 # https://github.com/ytsaurus/ytsaurus/pkgs/container/strawberry-nightly
 # skopeo inspect --format '{{range .RepoTags}}{{.}}\n{{end -}}' docker://ghcr.io/ytsaurus/strawberry-nightly:dev-2025-07-23-8c5b9c9b908af8b2f883de051b62072e795d40d3
-export STRAWBERRY_IMAGE_PREVIOUS = ${YTSAURUS_REGISTRY}/strawberry:0.0.13
-export STRAWBERRY_IMAGE_CURRENT = ${YTSAURUS_REGISTRY}/strawberry:0.0.14
-export STRAWBERRY_IMAGE_FUTURE = ${YTSAURUS_REGISTRY}/strawberry:0.0.15
-export STRAWBERRY_IMAGE_NIGHTLY = ${YTSAURUS_REGISTRY}/strawberry-nightly:dev-2025-11-11-1c0bdefd8ef465063372487e8a7c2be8625418e3
+
+export STRAWBERRY_IMAGE ?= ${YTSAURUS_REGISTRY}/strawberry
+
+export STRAWBERRY_VERSION_PAST ?= 0.0.13
+export STRAWBERRY_VERSION_PREVIOUS ?= 0.0.14
+export STRAWBERRY_VERSION_CURRENT ?= 0.0.15
+export STRAWBERRY_VERSION_COMING ?= 0.0.15
+export STRAWBERRY_VERSION_FUTURE ?= 0.0.15
+
+export STRAWBERRY_IMAGE_NIGHTLY ?= ${STRAWBERRY_IMAGE}-nightly:dev-2026-01-30-8551ddfc8cba5a5c2cc72d1cd2de3f8cdc206280
 
 # https://github.com/ytsaurus/ytsaurus/pkgs/container/chyt
 # https://github.com/ytsaurus/ytsaurus/pkgs/container/chyt-nightly
 # skopeo inspect --format '{{range .RepoTags}}{{.}}\n{{end -}}' docker://ghcr.io/ytsaurus/chyt-nightly:dev-2025-07-23-85732937466aec6368c1582345afdedff70c5007
-export CHYT_IMAGE_PREVIOUS = ${YTSAURUS_REGISTRY}/chyt:2.16.0
-export CHYT_IMAGE_CURRENT = ${YTSAURUS_REGISTRY}/chyt:2.16.0
-export CHYT_IMAGE_FUTURE = ${YTSAURUS_REGISTRY}/chyt:2.17.4
-export CHYT_IMAGE_NIGHTLY = ${YTSAURUS_REGISTRY}/chyt-nightly:dev-2025-11-11-1ea9f902e888db24630cdef436de8348b433ac4f
+
+export CHYT_IMAGE ?= ${YTSAURUS_REGISTRY}/chyt
+
+export CHYT_VERSION_PAST ?= 2.16.0
+export CHYT_VERSION_PREVIOUS ?= 2.16.0
+export CHYT_VERSION_CURRENT ?= 2.17.4
+export CHYT_VERSION_COMING ?= 2.17.4
+export CHYT_VERSION_FUTURE ?= 2.17.4
+
+export CHYT_IMAGE_NIGHTLY ?= ${CHYT_IMAGE}-nightly:dev-2026-01-30-14313a1279bd3f096e4d621722d06f4dd511ce98
 
 define LOAD_TEST_IMAGES
-${YTSAURUS_IMAGE_23_2}
-${YTSAURUS_IMAGE_PREVIOUS}
-${YTSAURUS_IMAGE_CURRENT}
-${YTSAURUS_IMAGE_FUTURE}
-${QUERY_TRACKER_IMAGE_CURRENT}
-${CHYT_IMAGE_CURRENT}
+$(YTSAURUS_IMAGE_$(subst .,_,$(YTSAURUS_VERSION_PREVIOUS)))
+$(YTSAURUS_IMAGE_$(subst .,_,$(YTSAURUS_VERSION_CURRENT)))
+$(YTSAURUS_IMAGE_$(subst .,_,$(YTSAURUS_VERSION_COMING)))
+${QUERY_TRACKER_IMAGE}:${QUERY_TRACKER_VERSION_CURRENT}
+${CHYT_IMAGE}:${CHYT_VERSION_CURRENT}
 endef
 
-YTSAURUS_SAMPLE_IMAGE_24_1 = ${YTSAURUS_REGISTRY}/ytsaurus:stable-24.1.0-relwithdebinfo
+YTSAURUS_SAMPLE_IMAGE_CURRENT ?= ghcr.io/ytsaurus/ytsaurus:stable-25.2.2-relwithdebinfo
 
 define LOAD_SAMPLE_IMAGES
-${YTSAURUS_SAMPLE_IMAGE_24_1}
+${YTSAURUS_SAMPLE_IMAGE_CURRENT}
 endef

--- a/test/r8r/canondata/Components reconciler Minimal Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/Ytsaurus.yaml
@@ -41,7 +41,7 @@ spec:
         memory: "0"
     serviceType: NodePort
     transport: {}
-  jobImage: docker.io/library/python:3.8-slim
+  jobImage: mirror.gcr.io/library/python:3.12-slim
   primaryMasters:
     cellTag: 1
     instanceCount: 1

--- a/test/r8r/canondata/Components reconciler Remote Exec nodes Test/RemoteExecNodes.yaml
+++ b/test/r8r/canondata/Components reconciler Remote Exec nodes Test/RemoteExecNodes.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   coreImage: ghcr.io/ytsaurus/ytsaurus:stable-24.2.1
   instanceCount: 1
-  jobImage: docker.io/library/python:3.8-slim
+  jobImage: mirror.gcr.io/library/python:3.12-slim
   jobResources:
     limits:
       cpu: "4"

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Chyt.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Chyt.yaml
@@ -8,7 +8,7 @@ metadata:
   resourceVersion: "7"
 spec:
   createPublicClique: true
-  image: ghcr.io/ytsaurus/chyt:2.16.0
+  image: ghcr.io/ytsaurus/chyt:2.17.4
   makeDefault: true
   ytsaurus:
     name: test-ytsaurus

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Job yt-chyt-test-ytsaurus-init-job-release.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Job yt-chyt-test-ytsaurus-init-job-release.yaml
@@ -59,7 +59,7 @@ spec:
           value: http-proxies-lb.ytsaurus-components.svc.cluster.local
         - name: YT_TOKEN
           value: S71v40zcuoQ-6NY-jE_-HOvqVG2PrBPdGqwEzi6i
-        image: ghcr.io/ytsaurus/chyt:2.16.0
+        image: ghcr.io/ytsaurus/chyt:2.17.4
         name: ytsaurus-init
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Ytsaurus.yaml
@@ -41,7 +41,7 @@ spec:
         memory: "0"
     serviceType: NodePort
     transport: {}
-  jobImage: docker.io/library/python:3.8-slim
+  jobImage: mirror.gcr.io/library/python:3.12-slim
   primaryMasters:
     cellTag: 1
     instanceCount: 1

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-exec-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-exec-node-config.yaml
@@ -118,7 +118,7 @@ data:
                     "cri_image_cache"={
                         capacity=5368709120;
                     };
-                    "job_proxy_image"="docker.io/library/python:3.8-slim";
+                    "job_proxy_image"="mirror.gcr.io/library/python:3.12-slim";
                     "use_job_proxy_from_image"=%false;
                 };
                 "do_not_set_user_id"=%true;

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Ytsaurus.yaml
@@ -89,7 +89,7 @@ spec:
         memory: "0"
     serviceType: NodePort
     transport: {}
-  jobImage: docker.io/library/python:3.8-slim
+  jobImage: mirror.gcr.io/library/python:3.12-slim
   primaryMasters:
     cellTag: 1
     instanceCount: 1

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-exec-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-exec-node-config.yaml
@@ -118,7 +118,7 @@ data:
                     "cri_image_cache"={
                         capacity=5368709120;
                     };
-                    "job_proxy_image"="docker.io/library/python:3.8-slim";
+                    "job_proxy_image"="mirror.gcr.io/library/python:3.12-slim";
                     "use_job_proxy_from_image"=%false;
                 };
                 "do_not_set_user_id"=%true;

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Ytsaurus.yaml
@@ -90,7 +90,7 @@ spec:
         memory: "0"
     serviceType: NodePort
     transport: {}
-  jobImage: docker.io/library/python:3.8-slim
+  jobImage: mirror.gcr.io/library/python:3.12-slim
   primaryMasters:
     cellTag: 1
     instanceCount: 1

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-exec-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-exec-node-config.yaml
@@ -118,7 +118,7 @@ data:
                     "cri_image_cache"={
                         capacity=5368709120;
                     };
-                    "job_proxy_image"="docker.io/library/python:3.8-slim";
+                    "job_proxy_image"="mirror.gcr.io/library/python:3.12-slim";
                     "use_job_proxy_from_image"=%false;
                 };
                 "do_not_set_user_id"=%true;

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Ytsaurus.yaml
@@ -87,7 +87,7 @@ spec:
         memory: "0"
     serviceType: NodePort
     transport: {}
-  jobImage: docker.io/library/python:3.8-slim
+  jobImage: mirror.gcr.io/library/python:3.12-slim
   primaryMasters:
     cellTag: 1
     instanceCount: 1

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-exec-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-exec-node-config.yaml
@@ -118,7 +118,7 @@ data:
                     "cri_image_cache"={
                         capacity=5368709120;
                     };
-                    "job_proxy_image"="docker.io/library/python:3.8-slim";
+                    "job_proxy_image"="mirror.gcr.io/library/python:3.12-slim";
                     "use_job_proxy_from_image"=%false;
                 };
                 "do_not_set_user_id"=%true;

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/Ytsaurus.yaml
@@ -88,7 +88,7 @@ spec:
         memory: "0"
     serviceType: NodePort
     transport: {}
-  jobImage: docker.io/library/python:3.8-slim
+  jobImage: mirror.gcr.io/library/python:3.12-slim
   primaryMasters:
     cellTag: 1
     instanceCount: 1

--- a/test/r8r/canondata/Components reconciler With SPYT Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/Ytsaurus.yaml
@@ -41,7 +41,7 @@ spec:
         memory: "0"
     serviceType: NodePort
     transport: {}
-  jobImage: docker.io/library/python:3.8-slim
+  jobImage: mirror.gcr.io/library/python:3.12-slim
   primaryMasters:
     cellTag: 1
     instanceCount: 1

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-exec-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-exec-node-config.yaml
@@ -146,7 +146,7 @@ data:
                     "cri_image_cache"={
                         capacity=5368709120;
                     };
-                    "job_proxy_image"="docker.io/library/python:3.8-slim";
+                    "job_proxy_image"="mirror.gcr.io/library/python:3.12-slim";
                     "job_proxy_bind_mounts"=[
                         {
                             "external_path"="/etc/ssl/certs";

--- a/test/r8r/canondata/Components reconciler With all components Test/Deployment strawberry-controller.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Deployment strawberry-controller.yaml
@@ -72,7 +72,7 @@ spec:
         envFrom:
         - secretRef:
             name: yt-strawberry-controller-secret
-        image: ghcr.io/ytsaurus/strawberry:0.0.14
+        image: ghcr.io/ytsaurus/strawberry:0.0.15
         name: strawberry
         ports:
         - containerPort: 80

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-strawberry-controller-init-job-cluster.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-strawberry-controller-init-job-cluster.yaml
@@ -67,7 +67,7 @@ spec:
         envFrom:
         - secretRef:
             name: yt-strawberry-controller-secret
-        image: ghcr.io/ytsaurus/strawberry:0.0.14
+        image: ghcr.io/ytsaurus/strawberry:0.0.15
         name: ytsaurus-init
         resources: {}
         terminationMessagePolicy: FallbackToLogsOnError

--- a/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
@@ -157,7 +157,7 @@ spec:
         name: https-server-cert
   imagePullSecrets:
   - name: global-image-pull-secrets
-  jobImage: docker.io/library/python:3.8-slim
+  jobImage: mirror.gcr.io/library/python:3.12-slim
   masterCaches:
     cellTagMasterCaches: 0
     instanceCount: 1
@@ -259,7 +259,6 @@ spec:
         cpu: "0"
         memory: "0"
   queueAgents:
-    image: ghcr.io/ytsaurus/ytsaurus:stable-24.2.1
     instanceCount: 1
     loggers:
     - minLogLevel: info
@@ -309,7 +308,7 @@ spec:
         memory: "0"
   setHostnameAsFqdn: false
   strawberry:
-    image: ghcr.io/ytsaurus/strawberry:0.0.14
+    image: ghcr.io/ytsaurus/strawberry:0.0.15
     resources: {}
   tolerations:
   - key: global-toleration

--- a/test/r8r/components_test.go
+++ b/test/r8r/components_test.go
@@ -256,7 +256,7 @@ var _ = Describe("Components reconciler", Label("reconciler"), func() {
 		By("Creating minimal Ytsaurus spec", func() {
 			ytBuilder = &testutil.YtsaurusBuilder{
 				MinReadyInstanceCount: ptr.To(0), // Do not wait any pods.
-				Images:                testutil.CurrentImages,
+				Images:                testutil.TestImages,
 				Namespace:             namespace,
 			}
 			ytBuilder.CreateMinimal()

--- a/test/webhooks/ytsaurus_webhooks_test.go
+++ b/test/webhooks/ytsaurus_webhooks_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Test for Ytsaurus webhooks", func() {
 
 	newYtsaurus := func() *ytv1.Ytsaurus {
 		builder = &testutil.YtsaurusBuilder{
-			Images:    testutil.CurrentImages,
+			Images:    testutil.TestImages,
 			Namespace: namespace,
 		}
 		By("Creating new ytsaurus spec")
@@ -601,7 +601,7 @@ var _ = Describe("Tests for required operator version webhook validation", Label
 
 	newYtsaurus := func() *ytv1.Ytsaurus {
 		builder = &testutil.YtsaurusBuilder{
-			Images:    testutil.CurrentImages,
+			Images:    testutil.TestImages,
 			Namespace: namespace,
 		}
 


### PR DESCRIPTION
    Add ytsaurus epochs which defines set of docker images.
    Use in e2e only: PREV=PREVIOUS, TEST=CURRENT, NEXT=COMING, LATE=FUTURE.
    Te test for other versions:
      make test-e2e TEST_YTSAURUS_VERSION=25.6.7
    
    Switch job image to python 3.12 from github mirror.
    CI hits docker.io rate limits. Python 3.8 is EOL.

