### PR TITLE
Added ctx into helpers methods to decouple them from specCtx, so progress reporters can safely invoke them and avoid panics

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -232,8 +232,9 @@ func (c *ClusterHealthReport) AddWarning(warning yterrors.Error, warningPath ypa
 }
 
 func (c *ClusterHealthReport) CollectAlerts(ytClient yt.Client, alertPath ypath.Path) {
+	ctx := context.Background()
 	var alerts []yterrors.Error
-	if err := ytClient.GetNode(specCtx, alertPath, &alerts, nil); err != nil {
+	if err := ytClient.GetNode(ctx, alertPath, &alerts, nil); err != nil {
 		if yterrors.ContainsResolveError(err) {
 			log.Info("Cannot collect alerts", "error", err, "alert_path", alertPath)
 		} else {
@@ -247,12 +248,13 @@ func (c *ClusterHealthReport) CollectAlerts(ytClient yt.Client, alertPath ypath.
 }
 
 func (c *ClusterHealthReport) CollectNodes(ytClient yt.Client, basePath ypath.Path) {
+	ctx := context.Background()
 	type nodeAlerts struct {
 		Name   string           `yson:",value"`
 		Alerts []yterrors.Error `yson:"alerts,attr"`
 	}
 	var nodes []nodeAlerts
-	err := ytClient.ListNode(specCtx, basePath, &nodes, &yt.ListNodeOptions{
+	err := ytClient.ListNode(ctx, basePath, &nodes, &yt.ListNodeOptions{
 		Attributes: []string{"alerts"},
 	})
 	if err != nil {
@@ -268,8 +270,9 @@ func (c *ClusterHealthReport) CollectNodes(ytClient yt.Client, basePath ypath.Pa
 }
 
 func (c *ClusterHealthReport) CollectLostChunks(ytClient yt.Client, countPath ypath.Path) {
+	ctx := context.Background()
 	var count int
-	err := ytClient.GetNode(specCtx, countPath, &count, nil)
+	err := ytClient.GetNode(ctx, countPath, &count, nil)
 	if err != nil {
 		c.AddError(err, countPath)
 		return
@@ -288,6 +291,7 @@ func (c *ClusterHealthReport) CollectLostChunks(ytClient yt.Client, countPath yp
 }
 
 func (c *ClusterHealthReport) CollectTablets(ytClient yt.Client, basePath ypath.Path, attrs []string) {
+	ctx := context.Background()
 	type node struct {
 		Name  string         `yson:",value"`
 		Attrs map[string]any `yson:",attrs"`
@@ -295,7 +299,7 @@ func (c *ClusterHealthReport) CollectTablets(ytClient yt.Client, basePath ypath.
 	var nodes []node
 
 	err := ytClient.ListNode(
-		specCtx,
+		ctx,
 		basePath,
 		&nodes,
 		&yt.ListNodeOptions{

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -348,6 +348,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 
 		By("Starting cluster health reporter")
 		DeferCleanup(AttachProgressReporter(func() string {
+			ctx := context.Background()
 			proxyPort := consts.HTTPPortName
 			if ytBuilder.WithHTTPSOnlyProxy {
 				proxyPort = consts.HTTPSPortName
@@ -358,7 +359,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 			}
 			ytClient := getYtClient(httpClient, proxyPort+"://"+proxyAddress)
 			// NOTE: WhoAmI right now does not retry.
-			if _, err := ytClient.WhoAmI(specCtx, nil); err != nil {
+			if _, err := ytClient.WhoAmI(ctx, nil); err != nil {
 				return fmt.Sprintf("ytsaurus api error: %v", err)
 			}
 			var clusterHealth ClusterHealthReport


### PR DESCRIPTION
It should fix panic errors that happened [here](https://github.com/ytsaurus/ytsaurus-k8s-operator/actions/runs/20459727743/job/58791220875#step:9:7125)