### PR TITLE
Changed return value for some component with ComponentStatusReadyAfter

### DIFF
--- a/pkg/components/queue_agent.go
+++ b/pkg/components/queue_agent.go
@@ -116,7 +116,7 @@ func (qa *QueueAgent) doSync(ctx context.Context, dry bool) (ComponentStatus, er
 				return ComponentStatusReady(), err
 			}
 		} else {
-			return ComponentStatusReadyAfter("Not updating component"), err
+			return ComponentStatusReadyAfter("Not updating component"), nil
 		}
 	}
 

--- a/pkg/components/scheduler.go
+++ b/pkg/components/scheduler.go
@@ -155,7 +155,7 @@ func (s *Scheduler) doSync(ctx context.Context, dry bool) (ComponentStatus, erro
 				return ComponentStatusReady(), err
 			}
 		} else {
-			return ComponentStatusReadyAfter("Not updating component"), err
+			return ComponentStatusReadyAfter("Not updating component"), nil
 		}
 	}
 

--- a/pkg/components/strawberry_controller.go
+++ b/pkg/components/strawberry_controller.go
@@ -283,7 +283,7 @@ func (c *StrawberryController) doSync(ctx context.Context, dry bool) (ComponentS
 				return ComponentStatusReady(), err
 			}
 		} else {
-			return ComponentStatusReadyAfter("Not updating component"), err
+			return ComponentStatusReadyAfter("Not updating component"), nil
 		}
 	}
 

--- a/pkg/components/ui.go
+++ b/pkg/components/ui.go
@@ -286,7 +286,7 @@ func (u *UI) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 				return ComponentStatusReady(), err
 			}
 		} else {
-			return ComponentStatusReadyAfter("Not updating component"), err
+			return ComponentStatusReadyAfter("Not updating component"), nil
 		}
 	}
 

--- a/pkg/components/yql_agent.go
+++ b/pkg/components/yql_agent.go
@@ -167,7 +167,7 @@ func (yqla *YqlAgent) doSync(ctx context.Context, dry bool) (ComponentStatus, er
 				return ComponentStatusReady(), err
 			}
 		} else {
-			return ComponentStatusReadyAfter("Not updating component"), err
+			return ComponentStatusReadyAfter("Not updating component"), nil
 		}
 	}
 


### PR DESCRIPTION
_err_ is guaranteed to be _nil_ on that path, so return ComponentStatusReadyAfter("Not updating component"), nil would be clearer.