### PR TITLE
Update CA root bundle setup for Java

### DIFF
--- a/config/certmanager/ytsaurus-dev-ca.yaml
+++ b/config/certmanager/ytsaurus-dev-ca.yaml
@@ -67,13 +67,8 @@ spec:
     configMap:
       key: "ca-certificates.crt"
     additionalFormats:
-      pkcs12:
-        key: "ca-certificates.p12"
-        password: "none"
-        profile: "Modern2023"
       jks:
         key: "ca-certificates.jks"
-        password: "none"
     namespaceSelector:
       matchLabels:
         "app.kubernetes.io/part-of": "ytsaurus-dev"

--- a/config/samples/cluster_v1_tls.yaml
+++ b/config/samples/cluster_v1_tls.yaml
@@ -47,6 +47,19 @@ spec:
   # To run all components in host network you need at least max(instanceCount) worker nodes due to port clash.
   # hostNetwork: true
 
+  # Mount trusted CA certificates into `/etc/ssl/certs`.
+  # See config/certmanager/ytsaurus-dev-ca.yaml and trust-manager documentation.
+  # NOTE: `$JAVA_HOME/lib/security/cacerts` symlink to `/etc/ssl/certs/java/cacerts`
+  # caRootBundle:
+  #   kind: ConfigMap
+  #   name: ytsaurus-ca-root-bundle
+  #   key: ca-certificates.crt
+  #   items:
+  #     - key: ca-certificates.crt
+  #       path: ca-certificates.crt
+  #     - key: ca-certificates.jks
+  #       path: java/cacerts
+
   # Install certificate for internal CA.
   caBundle:
     # https://github.com/ytsaurus/ytsaurus-k8s-operator/blob/main/docs/api.md#fileobjectreference

--- a/pkg/testutil/spec_builders.go
+++ b/pkg/testutil/spec_builders.go
@@ -341,12 +341,8 @@ func (b *YtsaurusBuilder) WithHTTPSProxies(httpsCert string, httpsOnly bool) {
 				Path: "ca-certificates.crt",
 			},
 			{
-				Key:  "ca-certificates.p12",
-				Path: "ca-certificates.p12",
-			},
-			{
 				Key:  "ca-certificates.jks",
-				Path: "ca-certificates.jks",
+				Path: "java/cacerts",
 			},
 		},
 	}

--- a/test/r8r/canondata/Components reconciler With all components Test/Deployment strawberry-controller.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Deployment strawberry-controller.yaml
@@ -98,10 +98,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-client-init-job-user.yaml
@@ -85,10 +85,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-master-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-master-init-job-default.yaml
@@ -85,10 +85,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-strawberry-controller-init-job-cluster.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-strawberry-controller-init-job-cluster.yaml
@@ -88,10 +88,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-strawberry-controller-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-strawberry-controller-init-job-user.yaml
@@ -85,10 +85,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-yql-agent-init-job-yql-agent-environment.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-yql-agent-init-job-yql-agent-environment.yaml
@@ -85,10 +85,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-yql-agent-init-job-yql-agent-update-environment.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-yql-agent-init-job-yql-agent-update-environment.yaml
@@ -85,10 +85,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ca.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ca.yaml
@@ -190,10 +190,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet dnd.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet dnd.yaml
@@ -196,10 +196,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ds.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ds.yaml
@@ -190,10 +190,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet end.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet end.yaml
@@ -270,10 +270,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet hp.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet hp.yaml
@@ -205,10 +205,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ms.yaml
@@ -197,10 +197,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet msc.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet msc.yaml
@@ -190,10 +190,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet rp.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet rp.yaml
@@ -193,10 +193,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet sch.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet sch.yaml
@@ -190,10 +190,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet yqla.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet yqla.yaml
@@ -198,10 +198,8 @@ spec:
           items:
           - key: ca-certificates.crt
             path: ca-certificates.crt
-          - key: ca-certificates.p12
-            path: ca-certificates.p12
           - key: ca-certificates.jks
-            path: ca-certificates.jks
+            path: java/cacerts
           name: ytsaurus-dev-ca-root-bundle
         name: ca-root-bundle
       - configMap:

--- a/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
@@ -13,10 +13,8 @@ spec:
     items:
     - key: ca-certificates.crt
       path: ca-certificates.crt
-    - key: ca-certificates.p12
-      path: ca-certificates.p12
     - key: ca-certificates.jks
-      path: ca-certificates.jks
+      path: java/cacerts
     name: ytsaurus-dev-ca-root-bundle
   clusterFeatures:
     httpProxyHaveChytAddress: true


### PR DESCRIPTION
Mount CA bundle in Java Key Store format with default password "changeme"
into /etc/ssl/certs/java/cacerts.

`$JAVA_HOME/lib/security/cacerts` symlink to `/etc/ssl/certs/java/cacerts`

To check run: keytool -list -cacerts -storepass changeit

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
