### PR TITLE
test: default timeout 1h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,13 @@ GINKGO_LABEL_FILTER ?=
 ## Tests parallelism.
 GINKGO_PROCS ?= 2
 
+## Tests timeout.
+GINKGO_TIMEOUT ?= 1h
+
 GINKGO_FLAGS += --vv
 GINKGO_FLAGS += --silence-skips
 GINKGO_FLAGS += --trace
-GINKGO_FLAGS += --timeout=1h
+GINKGO_FLAGS += --timeout=${GINKGO_TIMEOUT}
 GINKGO_FLAGS += --poll-progress-after=2m
 GINKGO_FLAGS += --poll-progress-interval=1m
 GINKGO_FLAGS += --junit-report=report.xml
@@ -141,7 +144,6 @@ else
 	REMOVE_CANONIZED = : dry-run rm -fr
 endif
 
-GO_TEST_FLAGS += -timeout 1800s
 GO_TEST_FLAGS += -coverprofile cover.out
 
 ##@ General


### PR DESCRIPTION
Remove second 30m timeout.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
