### PR TITLE
Switch release tag to standard golang scheme

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - 'release/0\.[0-9]+\.[0-9]+'
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'
 
 jobs:
   release:
@@ -12,4 +12,4 @@ jobs:
     uses: ./.github/workflows/subflow_release.yaml
     secrets: inherit
     with:
-      release_version: ${GITHUB_REF#refs/*/release/}
+      release_version: ${GITHUB_REF#refs/tags/v}


### PR DESCRIPTION
To use "api" module in external code it must be versioned correctly.
Also go uses version tag as version for "main" module in build-info.

Link: https://go.dev/doc/modules/version-numbers
Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
