### PR TITLE
spyt: fix ca root bundle env in init job

### DIFF
--- a/pkg/components/spyt.go
+++ b/pkg/components/spyt.go
@@ -180,7 +180,7 @@ func (s *Spyt) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 			})
 		}
 
-		container.Env = env
+		container.Env = append(container.Env, env...)
 	}
 
 	status, err = s.initEnvironment.Sync(ctx, dry)


### PR DESCRIPTION
Unfortunately these components are not integrated yet into "r8r" tests.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
