### PR TITLE
Use golang builder from mirror.gcr.io/library/golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG REVISION
 ARG BUILD_DATE
 
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM mirror.gcr.io/library/golang:1.24 AS builder
 
 ARG VERSION
 


### PR DESCRIPTION
GitHub actions hit DockerHub rate limits from time to time.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
