### PR TITLE
Add NodePort service type to rpc proxies in local cluster sample

### DIFF
--- a/config/samples/cluster_v1_local.yaml
+++ b/config/samples/cluster_v1_local.yaml
@@ -64,10 +64,12 @@ spec:
       role: control
 
   rpcProxies:
-    - instanceCount: 1
+    - serviceType: NodePort
+      instanceCount: 1
       loggers: *loggers
       role: default
-    - instanceCount: 1
+    - serviceType: NodePort
+      instanceCount: 1
       loggers: *loggers
       role: heavy
 


### PR DESCRIPTION
Improvements for working with RPC proxies out of the box. Simplifies the quick start guide when working with Apache Flink.
https://github.com/ytsaurus/ytsaurus-flyt/tree/main/flink-connector-ytsaurus#step-1---installing-ytsaurus

Changes in docs https://github.com/ytsaurus/ytsaurus/pull/1626