### PR TITLE
Fix kube-rbac-proxy in compat test

### DIFF
--- a/compat_test.sh
+++ b/compat_test.sh
@@ -3,7 +3,12 @@
 script_name=$0
 
 from_version="0.27.0"
+from_args=(
+    --set "controllerManager.kubeRbacProxy.image.repository=quay.io/brancz/kube-rbac-proxy"
+    --set "controllerManager.kubeRbacProxy.image.tag=v0.20.2"
+)
 to_version="trunk"
+to_args=()
 helm_chart="oci://ghcr.io/ytsaurus/ytop-chart"
 cluster_spec="config/samples/cluster_v1_local.yaml"
 cluster_name="minisaurus"
@@ -40,7 +45,7 @@ done
 
 set -eux -o pipefail
 
-helm install ytsaurus ${helm_chart} --version ${from_version} --wait
+helm install ytsaurus ${helm_chart} --version ${from_version} "${from_args[@]}" --wait
 
 kubectl get crd -l app.kubernetes.io/part-of=ytsaurus-k8s-operator -L app.kubernetes.io/version
 
@@ -58,7 +63,7 @@ if [[ "$to_version" == "trunk" ]]; then
         --set controllerManager.manager.image.tag=trunk
     kubectl wait ytsaurus/${cluster_name} --for=jsonpath="{.status.conditions[?(@.type=='OperatorVersion')].message}='${to_version}'" --timeout=1m
 else
-    helm upgrade ytsaurus --install ${helm_chart} --version ${to_version} --wait
+    helm upgrade ytsaurus --install ${helm_chart} --version ${to_version} "${to_args[@]}" --wait
 fi
 
 kubectl get crd -l app.kubernetes.io/part-of=ytsaurus-k8s-operator -L app.kubernetes.io/version


### PR DESCRIPTION
All versions before v0.30.0 are broken after removal of deprecated
kube-rbac-proxy docker image "gcr.io/kubebuilder/kube-rbac-proxy".

Use fresh "quay.io/brancz/kube-rbac-proxy:v0.20.2" instead.

Issue: #400
Link: https://github.com/brancz/kube-rbac-proxy
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
