### PR TITLE
Add cluster states "Preparing" and "UpdateBlocked"

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -973,11 +973,13 @@ type ClusterState string
 const (
 	ClusterStateCreated         ClusterState = "Created"
 	ClusterStateInitializing    ClusterState = "Initializing"
+	ClusterStatePreparing       ClusterState = "Preparing"
 	ClusterStateRunning         ClusterState = "Running"
 	ClusterStateReconfiguration ClusterState = "Reconfiguration"
 	ClusterStateUpdating        ClusterState = "Updating"
-	ClusterStateUpdateFinishing ClusterState = "UpdateFinishing"
-	ClusterStateCancelUpdate    ClusterState = "CancelUpdate"
+	ClusterStateUpdateCanceled  ClusterState = "UpdateCanceled"
+	ClusterStateUpdateBlocked   ClusterState = "UpdateBlocked"
+	ClusterStateUpdateFinished  ClusterState = "UpdateFinished"
 )
 
 type UpdateState string

--- a/controllers/component_manager.go
+++ b/controllers/component_manager.go
@@ -247,7 +247,7 @@ func (cm *ComponentManager) FetchStatus(ctx context.Context) error {
 			cm.status.allReady = false
 			cm.status.allRunning = false
 			cm.status.allReadyOrUpdating = false
-			if cm.ytsaurus.GetClusterState() == ytv1.ClusterStateRunning {
+			if cm.ytsaurus.IsReadyToUpdate() {
 				logger.Info("Cluster needs reconfiguration because component is not running",
 					"component", component.GetFullName(),
 					"status", status.SyncStatus,

--- a/controllers/update_flow_steps.go
+++ b/controllers/update_flow_steps.go
@@ -20,7 +20,7 @@ const (
 )
 
 var terminateTransitions = map[ytv1.UpdateState]ytv1.ClusterState{
-	ytv1.UpdateStateImpossibleToStart: ytv1.ClusterStateCancelUpdate,
+	ytv1.UpdateStateImpossibleToStart: ytv1.ClusterStateUpdateCanceled,
 }
 
 type flowCondition func(ctx context.Context, ytsaurus *apiProxy.Ytsaurus, componentManager *ComponentManager) stepResultMark
@@ -127,7 +127,7 @@ func (f *flowTree) execute(ctx context.Context, ytsaurus *apiProxy.Ytsaurus, com
 		// executed the last step in the flow — setting the cluster state
 		clusterState := terminateTransitions[currentState]
 		if clusterState == "" {
-			clusterState = ytv1.ClusterStateUpdateFinishing
+			clusterState = ytv1.ClusterStateUpdateFinished
 		}
 		ytsaurus.LogUpdate(
 			ctx,

--- a/controllers/ytsaurus_controller.go
+++ b/controllers/ytsaurus_controller.go
@@ -168,24 +168,20 @@ func (r *YtsaurusReconciler) Sync(ctx context.Context, resource *ytv1.Ytsaurus) 
 		return ctrl.Result{Requeue: true}, err
 
 	case ytv1.ClusterStateInitializing:
-		// Ytsaurus has finished initializing, and is running now.
 		if cm.status.allRunning {
-			logger.Info("Ytsaurus has synced and is running now")
-			err := ytsaurus.SaveClusterState(ctx, ytv1.ClusterStateRunning)
+			logger.Info("Ytsaurus has initialized and is preparing now")
+			err := ytsaurus.SaveClusterState(ctx, ytv1.ClusterStatePreparing)
 			return ctrl.Result{Requeue: true}, err
 		}
 
-	case ytv1.ClusterStateRunning, ytv1.ClusterStateReconfiguration, ytv1.ClusterStateUpdateFinishing:
+	case ytv1.ClusterStatePreparing, ytv1.ClusterStateRunning, ytv1.ClusterStateUpdateBlocked:
+		// All IsReadyToUpdate cluster states are handled here.
 		// Apply current update plan and choose components to update.
 		cm.applyUpdatePlan(resource.GetUpdatePlan())
 
-		// All status updates _must_ be in one transaction with observed generation and new cluster state.
+		// Switching into final states like Running or UpdateBlocked _must_ be in one
+		// transaction with all status updates and updating observed generation.
 		needStatusUpdate := ytsaurus.SyncObservedGeneration()
-
-		if ytsaurus.GetUpdateState() != ytv1.UpdateStateUndefined {
-			ytsaurus.ClearUpdateStatus()
-			needStatusUpdate = true
-		}
 
 		// There may be the case when some components needed update, but spec was reverted
 		// and Updating never happen — so blocked components column need to be always actualized.
@@ -201,7 +197,7 @@ func (r *YtsaurusReconciler) Sync(ctx context.Context, resource *ytv1.Ytsaurus) 
 			}
 
 		case !cm.status.allRunning:
-			logger.Info("Ytsaurus needs initialization of some components")
+			logger.Info("Ytsaurus needs reconfiguration for some components")
 			if ytsaurus.SetClusterState(ytv1.ClusterStateReconfiguration) {
 				needStatusUpdate = true
 			}
@@ -227,8 +223,7 @@ func (r *YtsaurusReconciler) Sync(ctx context.Context, resource *ytv1.Ytsaurus) 
 			logger.Info("Ytsaurus components update is blocked",
 				"cannotUpdate", cm.status.cannotUpdate,
 			)
-			// TODO: Add cluster state "UpdateBlocked".
-			if ytsaurus.SetClusterState(ytv1.ClusterStateRunning) {
+			if ytsaurus.SetClusterState(ytv1.ClusterStateUpdateBlocked) {
 				needStatusUpdate = true
 			}
 		}
@@ -239,37 +234,43 @@ func (r *YtsaurusReconciler) Sync(ctx context.Context, resource *ytv1.Ytsaurus) 
 			return ctrl.Result{Requeue: true}, err
 		}
 
-		if ytsaurus.IsRunning() {
-			// All done, nothing change - do not requeue reconcile.
-			return ctrl.Result{}, nil
+		// All done, nothing has changed - do not requeue reconcile.
+		return ctrl.Result{}, nil
+
+	case ytv1.ClusterStateReconfiguration:
+		if cm.status.allRunning {
+			logger.Info("Ytsaurus has reconfigured and is preparing now")
+			err := ytsaurus.SaveClusterState(ctx, ytv1.ClusterStatePreparing)
+			return ctrl.Result{Requeue: true}, err
 		}
 
 	case ytv1.ClusterStateUpdating:
 		cm.status.nowUpdating = ytsaurus.GetUpdatingComponents()
 
-		logger.Info("Ytsaurus update",
+		logger.Info("Ytsaurus updating",
 			"updateState", ytsaurus.GetUpdateState(),
 			"updatingComponents", cm.status.nowUpdating,
 		)
 		ytsaurus.RecordNormal("Update", fmt.Sprintf("Update flow starting with %s, updating components: %v", ytsaurus.GetUpdateState(), cm.status.nowUpdating))
 
 		updateFlow := buildFlowTree(cm)
-		progressed, err := updateFlow.execute(ctx, ytsaurus, cm)
-		if err != nil {
+		if progressed, err := updateFlow.execute(ctx, ytsaurus, cm); err != nil {
 			return ctrl.Result{}, err
+		} else if progressed {
+			return ctrl.Result{Requeue: true}, nil
 		}
 
-		if progressed {
-			return ctrl.Result{Requeue: true}, err
-		}
-
-	case ytv1.ClusterStateCancelUpdate:
+	case ytv1.ClusterStateUpdateFinished:
 		ytsaurus.ClearUpdateStatus()
-		logger.Info("Ytsaurus update was canceled, ytsaurus is running now")
-		// We don't update observed generation because the update was not really finished,
-		// and it's still the old version running.
-		err := ytsaurus.SaveClusterState(ctx, ytv1.ClusterStateRunning)
-		return ctrl.Result{}, err
+		logger.Info("Ytsaurus update has finished and Ytsaurus is preparing now")
+		err := ytsaurus.SaveClusterState(ctx, ytv1.ClusterStatePreparing)
+		return ctrl.Result{Requeue: true}, err
+
+	case ytv1.ClusterStateUpdateCanceled:
+		ytsaurus.ClearUpdateStatus()
+		logger.Info("Ytsaurus update has canceled, ytsaurus is preparing now")
+		err := ytsaurus.SaveClusterState(ctx, ytv1.ClusterStatePreparing)
+		return ctrl.Result{Requeue: true}, err
 
 	default:
 		return ctrl.Result{}, fmt.Errorf("unknown cluster state: %q", ytsaurus.GetClusterState())

--- a/controllers/ytsaurus_local_test.go
+++ b/controllers/ytsaurus_local_test.go
@@ -3,7 +3,6 @@ package controllers_test
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"k8s.io/utils/ptr"
 
@@ -191,17 +190,7 @@ var _ = Describe("Ytsaurus Controller", func() {
 				ytsaurusResource.Spec.EnableFullUpdate = ptr.To(false)
 				testutil.UpdateObject(h, &ytv1.Ytsaurus{}, &ytsaurusResource)
 
-				By("Checking that cluster is running but not updated")
-				Consistently(func() bool {
-					ytsaurus := ytv1.Ytsaurus{}
-					testutil.GetObject(h, ytsaurusName, &ytsaurus)
-					if ytsaurus.Status.State != ytv1.ClusterStateRunning {
-						return false
-					}
-					sts := appsv1.StatefulSet{}
-					testutil.GetObject(h, "ms", &sts)
-					return sts.Spec.Template.Spec.Containers[0].Image != imageUpdated
-				}, 5*time.Second, 500*time.Millisecond).Should(BeTrue())
+				waitClusterState(h, ytv1.ClusterStateUpdateBlocked, ytsaurusResource.Generation)
 			})
 		})
 	})

--- a/docs/api.md
+++ b/docs/api.md
@@ -393,11 +393,13 @@ _Appears in:_
 | --- | --- |
 | `Created` |  |
 | `Initializing` |  |
+| `Preparing` |  |
 | `Running` |  |
 | `Reconfiguration` |  |
 | `Updating` |  |
-| `UpdateFinishing` |  |
-| `CancelUpdate` |  |
+| `UpdateCanceled` |  |
+| `UpdateBlocked` |  |
+| `UpdateFinished` |  |
 
 
 #### CommonRemoteNodeStatus

--- a/pkg/apiproxy/ytsaurus.go
+++ b/pkg/apiproxy/ytsaurus.go
@@ -63,6 +63,16 @@ func (c *Ytsaurus) SetClusterState(clusterState ytv1.ClusterState) bool {
 		return false
 	}
 	c.ytsaurus.Status.State = clusterState
+	readyToWork := metav1.ConditionFalse
+	if c.IsReadyToWork() {
+		readyToWork = metav1.ConditionTrue
+	}
+	c.SetStatusCondition(metav1.Condition{
+		Type:    consts.ConditionReadyToWork,
+		Status:  readyToWork,
+		Reason:  string(clusterState),
+		Message: fmt.Sprintf("Cluster state is %v", clusterState),
+	})
 	return true
 }
 
@@ -70,13 +80,17 @@ func (c *Ytsaurus) IsInitializing() bool {
 	return c.GetClusterState() == ytv1.ClusterStateInitializing
 }
 
-func (c *Ytsaurus) IsRunning() bool {
-	return c.GetClusterState() == ytv1.ClusterStateRunning
+func (c *Ytsaurus) IsReadyToWork() bool {
+	switch c.GetClusterState() {
+	case ytv1.ClusterStateRunning, ytv1.ClusterStateUpdateBlocked:
+		return true
+	}
+	return false
 }
 
 func (c *Ytsaurus) IsReadyToUpdate() bool {
 	switch c.GetClusterState() {
-	case ytv1.ClusterStateRunning, ytv1.ClusterStateUpdateFinishing:
+	case ytv1.ClusterStatePreparing, ytv1.ClusterStateRunning, ytv1.ClusterStateUpdateBlocked:
 		return true
 	}
 	return false

--- a/pkg/consts/conditions.go
+++ b/pkg/consts/conditions.go
@@ -3,6 +3,7 @@ package consts
 // Status conditions
 const (
 	ConditionOperatorVersion            = "OperatorVersion"
+	ConditionReadyToWork                = "ReadyToWork"
 	ConditionTimbertruckUserInitialized = "TimbertruckUserInitialized"
 )
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -457,12 +457,20 @@ func HaveClusterState(state ytv1.ClusterState) otypes.GomegaMatcher {
 	return HaveField("Status.State", state)
 }
 
+func HaveClusterStates(states ...ytv1.ClusterState) otypes.GomegaMatcher {
+	return HaveField("Status.State", BeElementOf(states))
+}
+
 func HaveClusterStateRunning() otypes.GomegaMatcher {
 	return HaveClusterState(ytv1.ClusterStateRunning)
 }
 
 func HaveClusterStateUpdating() otypes.GomegaMatcher {
 	return HaveClusterState(ytv1.ClusterStateUpdating)
+}
+
+func HaveClusterStateUpdateBlocked() otypes.GomegaMatcher {
+	return HaveClusterState(ytv1.ClusterStateUpdateBlocked)
 }
 
 func HaveStatusCondition(conditionType string, expected otypes.GomegaMatcher) otypes.GomegaMatcher {

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -815,11 +815,13 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				UpdateObject(ctx, ytsaurus)
 
 				By("Ensure cluster doesn't start updating")
-				ConsistentlyYtsaurus(ctx, ytsaurus, consistencyTimeout).Should(HaveClusterStateRunning())
+				ConsistentlyYtsaurus(ctx, ytsaurus, consistencyTimeout).Should(HaveClusterStates(
+					ytv1.ClusterStateRunning, ytv1.ClusterStatePreparing, ytv1.ClusterStateUpdateBlocked,
+				))
 
 				By("Ensure cluster generation is observed")
 				EventuallyYtsaurus(ctx, ytsaurus, reactionTimeout).Should(HaveObservedGeneration())
-				Expect(ytsaurus).Should(HaveClusterStateRunning())
+				Expect(ytsaurus).Should(HaveClusterStateUpdateBlocked())
 				Expect(ytsaurus.Status.UpdateStatus.UpdatingComponents).To(BeEmpty())
 				Expect(ytsaurus.Status.UpdateStatus.UpdatingComponentsSummary).To(BeEmpty())
 				Expect(ytsaurus.Status.UpdateStatus.BlockedComponentsSummary).ToNot(BeEmpty())
@@ -881,7 +883,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				Expect(ytsaurus.Status.UpdateStatus.BlockedComponentsSummary).ToNot(BeEmpty())
 
 				By("Wait cluster update with selector:ExecNodesOnly complete")
-				EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateRunning())
+				EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateUpdateBlocked())
 				Expect(ytsaurus).Should(HaveObservedGeneration())
 				Expect(ytsaurus.Status.UpdateStatus.UpdatingComponents).To(BeEmpty())
 				Expect(ytsaurus.Status.UpdateStatus.UpdatingComponentsSummary).To(BeEmpty())
@@ -909,7 +911,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				Expect(ytsaurus.Status.UpdateStatus.BlockedComponentsSummary).ToNot(BeEmpty())
 
 				By("Wait cluster update with selector:TabletNodesOnly complete")
-				EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateRunning())
+				EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateUpdateBlocked())
 				Expect(ytsaurus).Should(HaveObservedGeneration())
 				Expect(ytsaurus.Status.UpdateStatus.UpdatingComponents).To(BeEmpty())
 				Expect(ytsaurus.Status.UpdateStatus.UpdatingComponentsSummary).To(BeEmpty())
@@ -941,7 +943,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				Expect(ytsaurus.Status.UpdateStatus.BlockedComponentsSummary).ToNot(BeEmpty())
 
 				By("Wait cluster update with selector:MasterOnly complete")
-				EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateRunning())
+				EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateUpdateBlocked())
 				Expect(ytsaurus).Should(HaveObservedGeneration())
 				Expect(ytsaurus.Status.UpdateStatus.UpdatingComponents).To(BeEmpty())
 				Expect(ytsaurus.Status.UpdateStatus.UpdatingComponentsSummary).To(BeEmpty())
@@ -974,7 +976,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				Expect(ytsaurus.Status.UpdateStatus.BlockedComponentsSummary).ToNot(BeEmpty())
 
 				By("Wait cluster update with selector:StatelessOnly complete")
-				EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateRunning())
+				EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateUpdateBlocked())
 				Expect(ytsaurus).Should(HaveObservedGeneration())
 				Expect(ytsaurus.Status.UpdateStatus.UpdatingComponents).To(BeEmpty())
 				Expect(ytsaurus.Status.UpdateStatus.UpdatingComponentsSummary).To(BeEmpty())
@@ -1021,7 +1023,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				Expect(ytsaurus.Status.UpdateStatus.BlockedComponentsSummary).ToNot(BeEmpty())
 
 				By("Wait cluster update with selector:DataNodesOnly complete")
-				EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateRunning())
+				EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateUpdateBlocked())
 				Expect(ytsaurus).Should(HaveObservedGeneration())
 				Expect(ytsaurus.Status.UpdateStatus.UpdatingComponents).To(BeEmpty())
 				Expect(ytsaurus.Status.UpdateStatus.UpdatingComponentsSummary).To(BeEmpty())
@@ -1929,6 +1931,7 @@ exec "$@"`
 
 	}) // integration
 
+	// FIXME(khlebnikov): Refactor this - update just one component.
 	Context("update plan strategy testing", Label("update", "plan", "strategy"), func() {
 		var podsBeforeUpdate map[string]corev1.Pod
 
@@ -1981,6 +1984,7 @@ exec "$@"`
 					switch componentType {
 					case consts.QueryTrackerType:
 						ytsaurus.Spec.QueryTrackers.Image = ptr.To(testutil.TestImages.QueryTracker)
+						updateSpecToTriggerAllComponentUpdate(ytsaurus)
 					default:
 						updateSpecToTriggerAllComponentUpdate(ytsaurus)
 					}
@@ -1989,7 +1993,7 @@ exec "$@"`
 					EventuallyYtsaurus(ctx, ytsaurus, reactionTimeout).Should(HaveObservedGeneration())
 
 					By("Waiting cluster update completes")
-					EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateRunning())
+					EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateUpdateBlocked())
 
 					By("Fetching updated StatefulSet revision")
 					sts := appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: stsName}}
@@ -2063,6 +2067,7 @@ exec "$@"`
 					switch componentType {
 					case consts.SchedulerType:
 						ytsaurus.Spec.Schedulers.Image = ptr.To(testutil.TestImages.Core)
+						updateSpecToTriggerAllComponentUpdate(ytsaurus)
 					default:
 						updateSpecToTriggerAllComponentUpdate(ytsaurus)
 					}
@@ -2117,7 +2122,7 @@ exec "$@"`
 					}
 
 					By("Waiting cluster update completes")
-					EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateRunning())
+					EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateUpdateBlocked())
 
 					By("Fetching updated StatefulSet revision")
 					EventuallyObject(ctx, &sts, reactionTimeout).Should(WithTransform(
@@ -2204,7 +2209,7 @@ exec "$@"`
 					))
 
 					By("Waiting cluster update completes")
-					EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateRunning())
+					EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateUpdateBlocked())
 
 					By("Fetching updated StatefulSet revision")
 					EventuallyObject(ctx, &sts, reactionTimeout).Should(WithTransform(
@@ -2295,7 +2300,7 @@ exec "$@"`
 				}
 
 				By("Waiting for cluster update to complete")
-				EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateRunning())
+				EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateUpdateBlocked())
 
 				defaultSts := appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: defaultDndStsName}}
 				namedSts := appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: namedDndStsName}}

--- a/test/r8r/canondata/Components reconciler Minimal Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/Ytsaurus.yaml
@@ -129,6 +129,12 @@ status:
     reason: Ready
     status: "True"
     type: YtsaurusClientReady
+  - lastTransitionTime: null
+    message: Cluster state is Running
+    observedGeneration: 1
+    reason: Running
+    status: "True"
+    type: ReadyToWork
   observedGeneration: 1
   state: Running
   updateStatus: {}

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Ytsaurus.yaml
@@ -129,6 +129,12 @@ status:
     reason: Ready
     status: "True"
     type: YtsaurusClientReady
+  - lastTransitionTime: null
+    message: Cluster state is Running
+    observedGeneration: 1
+    reason: Running
+    status: "True"
+    type: ReadyToWork
   observedGeneration: 1
   state: Running
   updateStatus: {}

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Ytsaurus.yaml
@@ -185,6 +185,12 @@ status:
     reason: Ready
     status: "True"
     type: YtsaurusClientReady
+  - lastTransitionTime: null
+    message: Cluster state is Running
+    observedGeneration: 1
+    reason: Running
+    status: "True"
+    type: ReadyToWork
   observedGeneration: 1
   state: Running
   updateStatus: {}

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Ytsaurus.yaml
@@ -186,6 +186,12 @@ status:
     reason: Ready
     status: "True"
     type: YtsaurusClientReady
+  - lastTransitionTime: null
+    message: Cluster state is Running
+    observedGeneration: 1
+    reason: Running
+    status: "True"
+    type: ReadyToWork
   observedGeneration: 1
   state: Running
   updateStatus: {}

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Ytsaurus.yaml
@@ -181,6 +181,12 @@ status:
     reason: Ready
     status: "True"
     type: YtsaurusClientReady
+  - lastTransitionTime: null
+    message: Cluster state is Running
+    observedGeneration: 1
+    reason: Running
+    status: "True"
+    type: ReadyToWork
   observedGeneration: 1
   state: Running
   updateStatus: {}

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/Ytsaurus.yaml
@@ -182,6 +182,12 @@ status:
     reason: Ready
     status: "True"
     type: YtsaurusClientReady
+  - lastTransitionTime: null
+    message: Cluster state is Running
+    observedGeneration: 1
+    reason: Running
+    status: "True"
+    type: ReadyToWork
   observedGeneration: 1
   state: Running
   updateStatus: {}

--- a/test/r8r/canondata/Components reconciler With SPYT Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/Ytsaurus.yaml
@@ -129,6 +129,12 @@ status:
     reason: Ready
     status: "True"
     type: YtsaurusClientReady
+  - lastTransitionTime: null
+    message: Cluster state is Running
+    observedGeneration: 1
+    reason: Running
+    status: "True"
+    type: ReadyToWork
   observedGeneration: 1
   state: Running
   updateStatus: {}

--- a/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
@@ -464,6 +464,12 @@ status:
     reason: Ready
     status: "True"
     type: StrawberryControllerReady
+  - lastTransitionTime: null
+    message: Cluster state is Running
+    observedGeneration: 1
+    reason: Running
+    status: "True"
+    type: ReadyToWork
   observedGeneration: 1
   state: Running
   updateStatus: {}


### PR DESCRIPTION
Add Preparing as transitional state to make switch into Running always final.
Add UpdateBlocked to make clear signal about blocked pending updates.
Rename UpdateCanceled and UpdateFinished to follow naming scheme.

Add cluster status condition "ReadyToWork" to simplify waiting and record time.