### PR TITLE
Update helm in workflows

### DIFF
--- a/.github/workflows/subflow_release.yaml
+++ b/.github/workflows/subflow_release.yaml
@@ -24,10 +24,12 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      # https://github.com/Azure/setup-helm
+      # https://github.com/helm/helm/releases
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v5.0.0
         with:
-          version: v3.11.2
+          version: v3.18.6
 
       - name: Build
         shell: bash

--- a/.github/workflows/subflow_run_compat_tests.yaml
+++ b/.github/workflows/subflow_run_compat_tests.yaml
@@ -26,10 +26,12 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      # https://github.com/Azure/setup-helm
+      # https://github.com/helm/helm/releases
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v5.0.0
         with:
-          version: v3.11.2
+          version: v3.18.6
 
       - name: Build
         shell: bash

--- a/.github/workflows/subflow_run_e2e_tests.yaml
+++ b/.github/workflows/subflow_run_e2e_tests.yaml
@@ -73,10 +73,12 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Setup Helm
-        uses: azure/setup-helm@v1
+      # https://github.com/Azure/setup-helm
+      # https://github.com/helm/helm/releases
+      - name: Set up Helm
+        uses: azure/setup-helm@v5.0.0
         with:
-          version: v3.11.2
+          version: v3.18.6
 
       - name: Build YTsaurus operator
         shell: bash


### PR DESCRIPTION
Helm v3.11 it too ancient nowadays.
We are using kind v0.22 which by default use k8s v1.29
This epoch relates helm versions around v3.18

Link: https://github.com/kubernetes-sigs/kind/releases/tag/v0.22.0
Link: https://github.com/helm/helm/releases/tag/v3.18.6
Link: https://github.com/Azure/setup-helm/issues/242
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
