### PR TITLE
Fix default node selector and tolerations in image heater

### DIFF
--- a/pkg/components/server.go
+++ b/pkg/components/server.go
@@ -311,8 +311,8 @@ func (s *serverImpl) getImageHeaterTarget() *ImageHeaterTarget {
 	return &ImageHeaterTarget{
 		Images:           images,
 		ImagePullSecrets: s.commonSpec.ImagePullSecrets,
-		NodeSelector:     s.instanceSpec.NodeSelector,
-		Tolerations:      s.instanceSpec.Tolerations,
+		NodeSelector:     getNodeSelectorWithDefault(s.instanceSpec.NodeSelector, s.commonPodSpec.NodeSelector),
+		Tolerations:      getTolerationsWithDefault(s.instanceSpec.Tolerations, s.commonPodSpec.Tolerations),
 		NodeAffinity:     ptr.Deref(s.instanceSpec.Affinity, corev1.Affinity{}).NodeAffinity,
 	}
 }

--- a/test/r8r/canondata/Components reconciler With all components Test/DaemonSets ih-ca.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/DaemonSets ih-ca.yaml
@@ -70,7 +70,11 @@ spec:
       enableServiceLinks: false
       imagePullSecrets:
       - name: global-image-pull-secrets
+      nodeSelector:
+        global-node-selector: "true"
       terminationGracePeriodSeconds: 0
+      tolerations:
+      - key: global-toleration
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 100

--- a/test/r8r/canondata/Components reconciler With all components Test/DaemonSets ih-yqla.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/DaemonSets ih-yqla.yaml
@@ -70,7 +70,11 @@ spec:
       enableServiceLinks: false
       imagePullSecrets:
       - name: global-image-pull-secrets
+      nodeSelector:
+        global-node-selector: "true"
       terminationGracePeriodSeconds: 0
+      tolerations:
+      - key: global-toleration
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 100


### PR DESCRIPTION
Image heater should use same defaults from common spec as instance.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
