### PR TITLE
set replication factor <3 in master init job

### DIFF
--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -381,8 +381,8 @@ func (m *Master) createInitScript() (string, error) {
 		initCommands = append(
 			initCommands,
 			RunIfNonexistent(
-				"//sys/@replication_factor",
-				fmt.Sprintf("/usr/bin/yt set //sys/@replication_factor %d", m.cfgen.GetMaxReplicationFactor()),
+				"//@replication_factor",
+				fmt.Sprintf("/usr/bin/yt set //@replication_factor %d", m.cfgen.GetMaxReplicationFactor()),
 			),
 		)
 	}


### PR DESCRIPTION
For clusters with replication factor less than 3 (i.e. with 1 or 2 data nodes), we have to set `//@replication_factor` so system dyntables will be created with correct replication factor, otherwise tablet nodes will fail to flush their chunks to data nodes.

It could be just `//sys/@replication_factor`, but we set for `//` for users convenience, so they don't have to make additional setup steps since all writes for clusters with `size(dnd) < 3` will be failed anyway.