### PR TITLE
Update linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -347,6 +347,5 @@ linters:
       - path: '_test\.go'
         linters:
           - fatcontext
-          - forbidigo # TODO
           - gochecknoglobals
           - gosec

--- a/pkg/components/init_job_test.go
+++ b/pkg/components/init_job_test.go
@@ -119,7 +119,7 @@ var _ = Describe("InitJob", func() {
 					Namespace: namespace,
 				}, &batchJob)
 				return apierrors.IsNotFound(err)
-			}, waitTimeout, 100*time.Millisecond).Should(BeTrue())
+			}, waitTimeout, 100*time.Millisecond).Should(BeTrueBecause("init job %q should be deleted", "ms-init-job-dummy"))
 		})
 	})
 

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -372,7 +372,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 			}, bootstrapTimeout, pollInterval).Should(Succeed())
 			Expect(caBundleCertificates).ToNot(BeEmpty())
 			rootCAs := x509.NewCertPool()
-			Expect(rootCAs.AppendCertsFromPEM(caBundleCertificates)).To(BeTrue())
+			Expect(rootCAs.AppendCertsFromPEM(caBundleCertificates)).To(BeTrueBecause("CA bundle certificates should be parsed successfully"))
 			httpTransport.TLSClientConfig = &tls.Config{
 				RootCAs: rootCAs,
 			}
@@ -478,7 +478,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 
 			By("Checking YTsaurus HTTP client", func() {
 				// NOTE: NodeExists retries - see ReadRetryParams.
-				Expect(ytClient.NodeExists(ctx, ypath.Path("/"), nil)).To(BeTrue())
+				Expect(ytClient.NodeExists(ctx, ypath.Path("/"), nil)).To(BeTrueBecause("root node should exist via HTTP client"))
 				// NOTE: WhoAmI right now does not retry.
 				Eventually(ctx, func(ctx context.Context) (*yt.WhoAmIResult, error) {
 					return ytClient.WhoAmI(ctx, nil)
@@ -496,7 +496,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 
 			By("Checking YTsaurus HTTPS client", func() {
 				// NOTE: NodeExists retries - see ReadRetryParams.
-				Expect(ytClientHTTPS.NodeExists(ctx, ypath.Path("/"), nil)).To(BeTrue())
+				Expect(ytClientHTTPS.NodeExists(ctx, ypath.Path("/"), nil)).To(BeTrueBecause("root node should exist via HTTPS client"))
 				// NOTE: WhoAmI right now does not retry.
 				Eventually(ctx, func(ctx context.Context) (*yt.WhoAmIResult, error) {
 					return ytClientHTTPS.WhoAmI(ctx, nil)
@@ -550,7 +550,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 		ytRPCClient = getYtRPCClient(httpClient, ytProxyAddress, ytRPCProxyAddress)
 
 		By("Checking RPC proxy is working")
-		Expect(ytRPCClient.NodeExists(ctx, ypath.Path("/"), nil)).To(BeTrue())
+		Expect(ytRPCClient.NodeExists(ctx, ypath.Path("/"), nil)).To(BeTrueBecause("root node should exist via RPC client"))
 	})
 
 	JustBeforeEach(func(ctx context.Context) {
@@ -1099,7 +1099,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 					var value any
 					err := ytClient.GetNode(ctx, ypath.Path("//sys/scheduler/config/spec_template/issue_temporary_token"), &value, nil)
 					return value, err
-				}, upgradeTimeout, pollInterval).Should(BeTrue())
+				}, upgradeTimeout, pollInterval).Should(BeTrueBecause("scheduler config issue_temporary_token should be set"))
 			})
 
 		}) // update overrides
@@ -1184,7 +1184,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 						return false
 					}
 					return len(notGoodBundles) == 0
-				}, upgradeTimeout, pollInterval).Should(BeTrue())
+				}, upgradeTimeout, pollInterval).Should(BeTrueBecause("all tablet cell bundles should be in good health"))
 
 				By("Ban all tablet nodes")
 				for i := range ytsaurus.Spec.TabletNodes[0].InstanceCount {
@@ -1199,7 +1199,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 						return false
 					}
 					return len(notGoodBundles) > 0
-				}, reactionTimeout, pollInterval).Should(BeTrue())
+				}, reactionTimeout, pollInterval).Should(BeTrueBecause("some tablet cell bundles should not be in good health after banning"))
 
 				runImpossibleUpdateAndRollback(ytsaurus, ytClient)
 			})
@@ -1243,7 +1243,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 						return false
 					}
 					return lvcCount > 0
-				}, reactionTimeout, pollInterval).Should(BeTrue())
+				}, reactionTimeout, pollInterval).Should(BeTrueBecause("lost vital chunks count should be greater than zero after banning data nodes"))
 
 				runImpossibleUpdateAndRollback(ytsaurus, ytClient)
 			})
@@ -1258,7 +1258,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 
 			It("Should run with query tracker and check that query tracker rpc address set up correctly", func(ctx context.Context) {
 				By("Check that query tracker channel exists in cluster_connection")
-				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/@cluster_connection/query_tracker/stages/production/channel"), nil)).Should(BeTrue())
+				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/@cluster_connection/query_tracker/stages/production/channel"), nil)).Should(BeTrueBecause("query tracker channel should exist in cluster_connection"))
 			})
 
 		}) // update query-tracker
@@ -1272,25 +1272,25 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 			It("Should run with yql agent and check that yql agent channel options set up correctly", func(ctx context.Context) {
 
 				By("Check that yql agent channel exists in cluster_connection")
-				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/@cluster_connection/yql_agent/stages/production/channel"), nil)).Should(BeTrue())
+				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/@cluster_connection/yql_agent/stages/production/channel"), nil)).Should(BeTrueBecause("yql agent channel should exist in cluster_connection"))
 				result := true
 				Expect(ytClient.GetNode(ctx, ypath.Path("//sys/@cluster_connection/yql_agent/stages/production/channel/disable_balancing_on_single_address"), &result, nil)).Should(Succeed())
-				Expect(result).Should(BeFalse())
+				Expect(result).Should(BeFalseBecause("disable_balancing_on_single_address should be false"))
 
 				By("Check that access control object namespace 'queries' exists")
-				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries"), nil)).Should(BeTrue())
+				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries"), nil)).Should(BeTrueBecause("access control object namespace queries should exist"))
 
 				By("Check that access control object 'nobody' in namespace 'queries' exists")
-				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries/nobody"), nil)).Should(BeTrue())
+				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries/nobody"), nil)).Should(BeTrueBecause("access control object nobody in namespace queries should exist"))
 
 				By("Check that access control object 'everyone' in namespace 'queries' exists")
-				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries/everyone"), nil)).Should(BeTrue())
+				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries/everyone"), nil)).Should(BeTrueBecause("access control object everyone in namespace queries should exist"))
 
 				By("Check that access control object 'everyone-use' in namespace 'queries' exists")
-				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries/everyone-use"), nil)).Should(BeTrue())
+				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries/everyone-use"), nil)).Should(BeTrueBecause("access control object everyone-use in namespace queries should exist"))
 
 				By("Check that access control object 'everyone-share' in namespace 'queries' exists")
-				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries/everyone-share"), nil)).Should(BeTrue())
+				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries/everyone-share"), nil)).Should(BeTrueBecause("access control object everyone-share in namespace queries should exist"))
 
 				By("Check that access control object namespace 'queries' allows users to create children and owners to do everything")
 				queriesAcl := []map[string]interface{}{}
@@ -1352,8 +1352,8 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 			})
 
 			It("Should run with queue agent", func(ctx context.Context) {
-				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/queue_agents/queues"), nil)).Should(BeTrue())
-				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/queue_agents/consumers"), nil)).Should(BeTrue())
+				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/queue_agents/queues"), nil)).Should(BeTrueBecause("queue_agents/queues node should exist"))
+				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/queue_agents/consumers"), nil)).Should(BeTrueBecause("queue_agents/consumers node should exist"))
 			})
 
 		}) // update queue-agent
@@ -1486,7 +1486,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 						return false
 					}
 					return isTableCellHealthGood
-				}, upgradeTimeout, pollInterval).Should(BeTrue())
+				}, upgradeTimeout, pollInterval).Should(BeTrueBecause("tablet cell should be in good health"))
 
 				By("Create a dynamic table on a remote tablet node")
 
@@ -1506,7 +1506,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 						return false
 					}
 					return len(notGoodBundles) == 0
-				}, upgradeTimeout, pollInterval).Should(BeTrue())
+				}, upgradeTimeout, pollInterval).Should(BeTrueBecause("all tablet cell bundles should be in good health"))
 
 				By("Mounting the dynamic table")
 				errMount := ytClient.MountTable(ctx, ypath.Path(dynamicTableTest), &yt.MountTableOptions{})
@@ -1518,7 +1518,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 						return false
 					}
 					return isTableMounted
-				}, upgradeTimeout, pollInterval).Should(BeTrue())
+				}, upgradeTimeout, pollInterval).Should(BeTrueBecause("dynamic table should be in mounted state"))
 
 				By("Inserting a row into dynamic table")
 				Eventually(func(g Gomega) {
@@ -1696,7 +1696,7 @@ exec "$@"`
 				Expect(err).Should(Succeed())
 
 				_, err = cli.NodeExists(ctx, ypath.Path("/"), nil)
-				Expect(yterrors.ContainsErrorCode(err, yterrors.CodeRPCAuthenticationError)).Should(BeTrue())
+				Expect(yterrors.ContainsErrorCode(err, yterrors.CodeRPCAuthenticationError)).Should(BeTrueBecause("unauthenticated RPC request should produce CodeRPCAuthenticationError"))
 
 				By("Checking RPC proxy works with token")
 				cli = getYtRPCClient(httpClient, ytProxyAddress, ytRPCProxyAddress)
@@ -1737,21 +1737,21 @@ exec "$@"`
 				body, err := io.ReadAll(rsp.Body)
 				Expect(err).Should(Succeed())
 
-				Expect(json.Valid(body)).Should(BeTrue())
+				Expect(json.Valid(body)).Should(BeTrueBecause("monitoring response body should be valid JSON"))
 
 				var parsedBody map[string]any
 				Expect(json.Unmarshal(body, &parsedBody)).Should(Succeed())
 
 				sensors, ok := parsedBody["sensors"].([]any)
-				Expect(ok).Should(BeTrue())
+				Expect(ok).Should(BeTrueBecause("parsed body should contain sensors as []any"))
 				Expect(sensors).ShouldNot(BeEmpty())
 
 				sensor, ok := sensors[0].(map[string]any)
-				Expect(ok).Should(BeTrue())
+				Expect(ok).Should(BeTrueBecause("sensor should be a map[string]any"))
 				Expect("labels").Should(BeKeyOf(sensor))
 
 				labels, ok := sensor["labels"].(map[string]any)
-				Expect(ok).Should(BeTrue())
+				Expect(ok).Should(BeTrueBecause("sensor labels should be a map[string]any"))
 				Expect("host").Should(BeKeyOf(labels))
 				Expect("pod").Should(BeKeyOf(labels))
 				// We don not check the actual value, since it is something weird in our testing setup.
@@ -1872,7 +1872,7 @@ exec "$@"`
 						if !conn.Encrypted && component.Type == consts.RpcProxyType {
 							continue
 						}
-						Expect(conn.Encrypted).To(BeTrue(), "connection %q between %q and %q band %q", connID, component.Address, conn.Address, conn.MultiplexingBand)
+						Expect(conn.Encrypted).To(BeTrueBecause("connection %q between %q and %q band %q should be encrypted", connID, component.Address, conn.Address, conn.MultiplexingBand))
 					}
 				}
 			})
@@ -1902,7 +1902,7 @@ exec "$@"`
 				By("Waiting http proxy", func() {
 					Eventually(func(ctx context.Context) (bool, error) {
 						return ytClient.NodeExists(ctx, ypath.Path("/"), nil)
-					}, bootstrapTimeout, pollInterval, ctx).MustPassRepeatedly(5).Should(BeTrue())
+					}, bootstrapTimeout, pollInterval, ctx).MustPassRepeatedly(5).Should(BeTrueBecause("root node should exist via HTTP proxy after certificate reissue"))
 				})
 
 				// FIXME(khlebnikov): Workaround for DNS issues inside cluster.
@@ -2022,7 +2022,7 @@ exec "$@"`
 							}
 						}
 						return true
-					}, upgradeTimeout, pollInterval).Should(BeTrue())
+					}, upgradeTimeout, pollInterval).Should(BeTrueBecause("all %s pods should be on the new revision %s", stsName, updateRevision))
 
 					checkClusterHealth(ctx, ytClient)
 					checkChunkLocations(ytClient)
@@ -2097,7 +2097,7 @@ exec "$@"`
 								current.Status.UpdateRevision != "" &&
 								current.Status.UpdateRevision != current.Status.CurrentRevision
 						},
-						BeTrue(),
+						BeTrueBecause("StatefulSet %s should have update revision different from current revision", stsName),
 					))
 
 					oldRev := sts.Status.CurrentRevision
@@ -2111,7 +2111,7 @@ exec "$@"`
 							}
 						}
 						return true
-					}, 10*time.Second).Should(BeTrue())
+					}, 10*time.Second).Should(BeTrueBecause("all %s pods should remain on old revision %s", stsName, oldRev))
 
 					By("Manually delete component pods")
 					for name := range podsBeforeUpdate {
@@ -2150,7 +2150,7 @@ exec "$@"`
 							}
 						}
 						return true
-					}, upgradeTimeout, pollInterval).Should(BeTrue())
+					}, upgradeTimeout, pollInterval).Should(BeTrueBecause("all %s pods should be on the new revision %s", stsName, updateRevision))
 				})
 			},
 			Entry("update scheduler", Label(consts.GetStatefulSetPrefix(consts.SchedulerType)), consts.SchedulerType, consts.GetStatefulSetPrefix(consts.SchedulerType)),
@@ -2211,7 +2211,7 @@ exec "$@"`
 
 							return true
 						},
-						BeTrue(),
+						BeTrueBecause("StatefulSet %s should have RollingUpdate strategy with correct partition and maxUnavailable", stsName),
 					))
 
 					By("Waiting cluster update completes")
@@ -2242,7 +2242,7 @@ exec "$@"`
 							}
 						}
 						return true
-					}, upgradeTimeout, pollInterval).Should(BeTrue())
+					}, upgradeTimeout, pollInterval).Should(BeTrueBecause("all %s pods should be on the new revision %s", stsName, updateRevision))
 
 					By("Verifying only target component pods were recreated")
 					podsAfterUpdate := getComponentPods(ctx, namespace)
@@ -2300,8 +2300,8 @@ exec "$@"`
 				for name := range podsBeforeUpdate {
 					if strings.HasPrefix(name, namedDndStsName+"-") {
 						pod, stillExists := podsNow[name]
-						Expect(stillExists).To(BeTrue(), "named rack pod %s should still exist before its turn", name)
-						Expect(pod.DeletionTimestamp.IsZero()).To(BeTrue(), "named rack pod %s should not be deleting before its turn", name)
+						Expect(stillExists).To(BeTrueBecause("named rack pod %s should still exist before its turn", name))
+						Expect(pod.DeletionTimestamp.IsZero()).To(BeTrueBecause("named rack pod %s should not be deleting before its turn", name))
 					}
 				}
 
@@ -2327,7 +2327,7 @@ exec "$@"`
 						}
 					}
 					return true
-				}, upgradeTimeout, pollInterval).Should(BeTrue())
+				}, upgradeTimeout, pollInterval).Should(BeTrueBecause("all default rack pods should be on the new revision %s", defaultUpdateRevision))
 
 				By("Verifying named rack (3c25) pods are on the new revision")
 				EventuallyObject(ctx, &namedSts, reactionTimeout).Should(WithTransform(
@@ -2345,7 +2345,7 @@ exec "$@"`
 						}
 					}
 					return true
-				}, upgradeTimeout, pollInterval).Should(BeTrue())
+				}, upgradeTimeout, pollInterval).Should(BeTrueBecause("all named rack pods should be on the new revision %s", namedUpdateRevision))
 
 				checkClusterHealth(ctx, ytClient)
 				checkChunkLocations(ytClient)
@@ -2464,7 +2464,7 @@ func checkClusterHealth(ctx context.Context, ytClient yt.Client) {
 			var clusterHealth ClusterHealthReport
 			clusterHealth.Collect(ctx, ytClient)
 			return len(clusterHealth.Alerts) == 0 && len(clusterHealth.Errors) == 0
-		}, reactionTimeout, pollInterval).Should(BeTrue())
+		}, reactionTimeout, pollInterval).Should(BeTrueBecause("cluster should have no alerts and no errors"))
 	})
 
 	By("Checking that tablet cell bundles are in `good` health")
@@ -2474,7 +2474,7 @@ func checkClusterHealth(ctx context.Context, ytClient yt.Client) {
 			return false
 		}
 		return len(notGoodBundles) == 0
-	}, reactionTimeout, pollInterval).Should(BeTrue())
+	}, reactionTimeout, pollInterval).Should(BeTrueBecause("all tablet cell bundles should be in good health"))
 }
 
 func createTestUser(ytClient yt.Client) {
@@ -2489,7 +2489,7 @@ func createTestUser(ytClient yt.Client) {
 			return false, nil
 		}
 		return true, err
-	}).Should(BeTrue())
+	}).Should(BeTrueBecause("test user should be created successfully"))
 
 	By("Check that test user cannot access things they shouldn't")
 	hasPermission, err := ytClient.CheckPermission(specCtx, "test-user", yt.PermissionWrite, ypath.Path("//sys/groups/superusers"), nil)
@@ -2567,7 +2567,7 @@ func checkChunkLocations(ytClient yt.Client) {
 	err := ytClient.GetNode(specCtx, ypath.Path(realChunkLocationPath), &realChunkLocationsValue, nil)
 	Expect(err).Should(Or(Succeed(), Satisfy(yterrors.ContainsResolveError)))
 	if err == nil {
-		Expect(realChunkLocationsValue).Should(BeTrue())
+		Expect(realChunkLocationsValue).Should(BeTrueBecause("enable_real_chunk_locations should be true at %s", realChunkLocationPath))
 	}
 
 	var values []yson.ValueWithAttrs
@@ -2576,7 +2576,7 @@ func checkChunkLocations(ytClient yt.Client) {
 	})).Should(Succeed())
 
 	for _, node := range values {
-		Expect(node.Attrs["use_imaginary_chunk_locations"]).ShouldNot(BeTrue())
+		Expect(node.Attrs["use_imaginary_chunk_locations"]).ShouldNot(BeTrueBecause("use_imaginary_chunk_locations should not be set on data node"))
 	}
 }
 
@@ -2645,7 +2645,7 @@ func (o *TestOperation) Wait() *yt.OperationStatus {
 			return true
 		}
 		return false
-	}, operationTimeout, operationPollInterval, specCtx).Should(BeTrue())
+	}, operationTimeout, operationPollInterval, specCtx).Should(BeTrueBecause("operation %s should complete", o.Id))
 	return opStatus
 }
 

--- a/test/r8r/components_test.go
+++ b/test/r8r/components_test.go
@@ -418,7 +418,7 @@ var _ = Describe("Components reconciler", Label("reconciler"), func() {
 					requestQueue = slices.Delete(requestQueue, index, index+1)
 				}
 				return true, err
-			}, "60s", "0ms").Should(BeFalse())
+			}, "60s", "0ms").Should(BeFalseBecause("all reconciliation requests should be completed"))
 
 			By("Fetching events", func() {
 				k8sEvents = fetchEvents()


### PR DESCRIPTION
Replace all bare BeTrue()/BeFalse() gomega matchers with
BeTrueBecause()/BeFalseBecause() that include explicit failure
messages, and remove the forbidigo lint exclusion for test files.

Co-authored-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
