### PR TITLE
Fixed rollingUpdate bug for exec-nodes and added e2e test

### DIFF
--- a/pkg/components/exec_node.go
+++ b/pkg/components/exec_node.go
@@ -82,6 +82,12 @@ func NewExecNode(
 }
 
 func (n *ExecNode) Sync(ctx context.Context, dry bool) (ComponentStatus, error) {
+	if !dry {
+		if err := n.doBuildBase(); err != nil {
+			return ComponentStatusBlockedBy("cannot build exec node spec"), err
+		}
+	}
+
 	if n.ytsaurus.GetClusterState() == ytv1.ClusterStateUpdating {
 		if status, err := dispatchComponentUpdate(ctx, n.ytsaurus, n, &n.component, n.server, dry); status != nil {
 			return *status, err

--- a/pkg/components/exec_node_base.go
+++ b/pkg/components/exec_node_base.go
@@ -233,10 +233,6 @@ func (n *baseExecNode) addCRIServiceSidecar(cri *ytconfig.CRIConfigGenerator, po
 func (n *baseExecNode) doSyncBase(ctx context.Context, dry bool) (ComponentStatus, error) {
 	var err error
 	if !dry {
-		err = n.doBuildBase()
-		if err != nil {
-			return ComponentStatusBlockedBy("cannot build exec node spec"), err
-		}
 		err = resources.Sync(ctx, n.server, n.sidecarConfig)
 	}
 	return ComponentStatusWaitingFor("components"), err

--- a/pkg/components/exec_node_remote.go
+++ b/pkg/components/exec_node_remote.go
@@ -76,6 +76,11 @@ func NewRemoteExecNodes(
 
 func (n *RemoteExecNode) Sync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	if n.NeedSync() {
+		if !dry {
+			if err := n.doBuildBase(); err != nil {
+				return ComponentStatusBlockedBy("cannot build exec node spec"), err
+			}
+		}
 		return n.doSyncBase(ctx, dry)
 	}
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -743,3 +743,21 @@ func restartPod(ctx context.Context, namespace, name string) {
 		HaveField("Status.Phase", Equal(corev1.PodRunning)),
 	))
 }
+
+func findContainer(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+func findVolumeMount(volumeMounts []corev1.VolumeMount, name string) *corev1.VolumeMount {
+	for i := range volumeMounts {
+		if volumeMounts[i].Name == name {
+			return &volumeMounts[i]
+		}
+	}
+	return nil
+}

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -2166,6 +2166,22 @@ exec "$@"`
 					case consts.HttpProxyType:
 						ytsaurus.Spec.HTTPProxies[0].InstanceCount = int32(6)
 						ytsaurus.Spec.HTTPProxies[0].MinReadyInstanceCount = ptr.To(minReady)
+					case consts.ExecNodeType:
+						execNode := &ytsaurus.Spec.ExecNodes[0]
+						execNode.InstanceCount = 3
+						execNode.MinReadyInstanceCount = ptr.To(minReady)
+						execNode.Privileged = true
+						ytBuilder.SetupCRIJobEnvironment(execNode)
+
+						foundNodeDataMount := false
+						for i := range execNode.VolumeMounts {
+							if execNode.VolumeMounts[i].Name != "node-data" {
+								continue
+							}
+							execNode.VolumeMounts[i].MountPropagation = ptr.To(corev1.MountPropagationBidirectional)
+							foundNodeDataMount = true
+						}
+						Expect(foundNodeDataMount).To(BeTrue(), "node-data volume mount")
 					}
 					ytsaurus.Spec.UpdatePlan = []ytv1.ComponentUpdateSelector{
 						{
@@ -2213,6 +2229,44 @@ exec "$@"`
 						},
 						BeTrue(),
 					))
+
+					if componentType == consts.ExecNodeType {
+
+						By("Verify rolling update keeps exec-node CRI pod spec enrichments")
+						Eventually(func(g Gomega) {
+							g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: stsName}, &sts)).To(Succeed())
+
+							podSpec := sts.Spec.Template.Spec
+							g.Expect(podSpec.InitContainers).ToNot(BeEmpty())
+							for _, initContainer := range podSpec.InitContainers {
+								g.Expect(initContainer.SecurityContext).ToNot(BeNil(), initContainer.Name)
+								g.Expect(initContainer.SecurityContext.Privileged).ToNot(BeNil(), initContainer.Name)
+								g.Expect(*initContainer.SecurityContext.Privileged).To(BeTrue(), initContainer.Name)
+							}
+
+							serverContainer := findContainer(podSpec.Containers, consts.YTServerContainerName)
+							g.Expect(serverContainer).ToNot(BeNil())
+							g.Expect(serverContainer.SecurityContext).ToNot(BeNil())
+							g.Expect(serverContainer.SecurityContext.Privileged).ToNot(BeNil())
+							g.Expect(*serverContainer.SecurityContext.Privileged).To(BeTrue())
+
+							serverMount := findVolumeMount(serverContainer.VolumeMounts, "node-data")
+							g.Expect(serverMount).ToNot(BeNil())
+							g.Expect(serverMount.MountPropagation).ToNot(BeNil())
+							g.Expect(*serverMount.MountPropagation).To(Equal(corev1.MountPropagationBidirectional))
+
+							jobsContainer := findContainer(podSpec.Containers, consts.JobsContainerName)
+							g.Expect(jobsContainer).ToNot(BeNil())
+							g.Expect(jobsContainer.SecurityContext).ToNot(BeNil())
+							g.Expect(jobsContainer.SecurityContext.Privileged).ToNot(BeNil())
+							g.Expect(*jobsContainer.SecurityContext.Privileged).To(BeTrue())
+
+							jobsMount := findVolumeMount(jobsContainer.VolumeMounts, "node-data")
+							g.Expect(jobsMount).ToNot(BeNil())
+							g.Expect(jobsMount.MountPropagation).ToNot(BeNil())
+							g.Expect(*jobsMount.MountPropagation).To(Equal(corev1.MountPropagationHostToContainer))
+						}, reactionTimeout, pollInterval).Should(Succeed())
+					}
 
 					By("Waiting cluster update completes")
 					EventuallyYtsaurus(ctx, ytsaurus, upgradeTimeout).Should(HaveClusterStateUpdateBlocked())
@@ -2262,6 +2316,7 @@ exec "$@"`
 				})
 			},
 			Entry("update http-proxy", Label(consts.GetStatefulSetPrefix(consts.HttpProxyType)), consts.HttpProxyType, consts.GetStatefulSetPrefix(consts.HttpProxyType), int32(2)),
+			Entry("update exec-node with CRI sidecar", Label(consts.GetStatefulSetPrefix(consts.ExecNodeType)), consts.ExecNodeType, consts.GetStatefulSetPrefix(consts.ExecNodeType), int32(2)),
 		)
 		Context("concurrent rolling update for multiple data-node groups", Label("rollingupdate-dnd"), func() {
 			const (


### PR DESCRIPTION
During `RollingUpdate` of exec nodes, the operator may call `server.Sync()` before exec-node-specific pod-spec enrichment has been built for the current reconcile loop.

[handleRollingUpdatingClusterState](https://github.com/ytsaurus/ytsaurus-k8s-operator/blob/main/pkg/components/helpers.go#L361) calls `server.Sync()` directly during the rolling for partition advancement.

However, `ComponentManager` is recreated on each reconcile, so [serverImpl.builtStatefulSet](https://github.com/ytsaurus/ytsaurus-k8s-operator/blob/main/pkg/components/server.go#L408) starts empty on each loop.

For exec nodes, the pod template is enriched in [doBuildBase](https://github.com/ytsaurus/ytsaurus-k8s-operator/blob/main/pkg/components/exec_node_base.go#L56), but in the broken flow that build step is only done from [doSyncBase](https://github.com/ytsaurus/ytsaurus-k8s-operator/blob/main/pkg/components/exec_node_base.go#L233). During rolling update, control returns early from `dispatchComponentUpdate()`, so `doSyncBase()` is not reached before `server.Sync()` is invoked.

That means `server.Sync()` can build the StatefulSet from the generic `serverImpl.rebuildStatefulSet()` path first, producing an incomplete pod spec.


**Fix**:

- keep `doBuildBase()` as the only place that enriches the pod spec
- remove `doBuildBase()` from `doSyncBase()`
- call `doBuildBase()` unconditionally before entering `dispatchComponentUpdate()` in `ExecNode.Sync()`
- call `doBuildBase()` before `doSyncBase()` in `RemoteExecNode.Sync()`