### PR TITLE
Fixed pre-check failure triggering reconciler exponential backoff

### DIFF
--- a/pkg/components/helpers.go
+++ b/pkg/components/helpers.go
@@ -500,7 +500,7 @@ func runPrechecks(ctx context.Context, ytsaurus *apiproxy.Ytsaurus, cmp Componen
 			Reason:  "PreChecksFailed",
 			Message: msg,
 		})
-		return ptr.To(ComponentStatusBlocked("%v", msg)), yterrors.Err(msg)
+		return ptr.To(ComponentStatusBlocked("%v", msg)), nil
 	}
 	// Set PreChecksCompleted condition for this component
 	ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{


### PR DESCRIPTION
Closes #787.
The `ComponentStatus` already carries the full semantic (`SyncStatusBlocked` + message). The error
was redundant — its only effect was accidentally triggering backoff.
With that fix, `SyncStatusBlocked` now propagates normally through FetchStatus and cm.Sync(). The reconciler requeues on the regular schedule instead of backing off.