### PR TITLE
Use json for logging by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -475,7 +475,7 @@ build: generate-code ## Build manager binary.
 .PHONY: run
 run: generate-code manifests ## Run a controller from your host.
 	K8S_CLUSTER_DOMAIN=cluster.local \
-	go run ${GOFLAGS} -ldflags "$(GO_LDFLAGS)" ./main.go
+	go run ${GOFLAGS} -ldflags "$(GO_LDFLAGS)" ./main.go --zap-devel
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.

--- a/main.go
+++ b/main.go
@@ -88,7 +88,6 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1, "The maximum number of concurrent Reconciles which can be run")
 	opts := zap.Options{
-		Development: true,
 		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)

--- a/ytop-chart/values.yaml
+++ b/ytop-chart/values.yaml
@@ -35,6 +35,8 @@ controllerManager:
       - --health-probe-bind-address=:8081
       - --metrics-bind-address=:8080
       - --leader-elect
+      - --zap-log-level=debug
+      # - --zap-devel
     # env: environment variables injected into the manager container.
     env:
       # GOMAXPROCS: limits the number of OS threads used by the Go runtime.


### PR DESCRIPTION
- disable development logging mode by default
- enable development logging mode for "make run"
- set log level to debug in helm chart

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
