### PR TITLE
Fix manual restart of init jobs

### DIFF
--- a/pkg/apiproxy/ytsaurus.go
+++ b/pkg/apiproxy/ytsaurus.go
@@ -100,6 +100,19 @@ func (c *Ytsaurus) IsReadyToUpdate() bool {
 	return false
 }
 
+func (c *Ytsaurus) IsReadyForInitJobs() bool {
+	switch c.GetClusterState() {
+	case ytv1.ClusterStateInitializing,
+		ytv1.ClusterStatePreparing,
+		ytv1.ClusterStateRunning,
+		ytv1.ClusterStateReconfiguration,
+		ytv1.ClusterStateMaintenance,
+		ytv1.ClusterStateUpdateBlocked:
+		return true
+	}
+	return false
+}
+
 func (c *Ytsaurus) IsUpdating() bool {
 	return c.GetClusterState() == ytv1.ClusterStateUpdating
 }

--- a/pkg/components/init_job.go
+++ b/pkg/components/init_job.go
@@ -146,8 +146,9 @@ func (j *InitJob) Restart() {
 	j.owner.RemoveStatusCondition(j.statusCondition)
 }
 
-// IsCompleted returns true if job exists and finished for any reason.
-// Removing either job spec or condition returns job into non-completed state.
+// IsCompleted returns true if job spec and config exist and job status condition is "True".
+// NOTE: Not checking job success to allow manual setting condition for failing jobs.
+// NOTE: Removing either job spec, config or condition triggers job restart.
 func (j *InitJob) IsCompleted() bool {
 	return j.Exists() && j.owner.IsStatusConditionTrue(j.statusCondition)
 }
@@ -222,10 +223,10 @@ func (j *InitJob) Build() *batchv1.Job {
 	}
 	job := j.initJob.Build()
 	job.Spec = batchv1.JobSpec{
+		// NOTE: Jobs are not deleted automatically. Delete triggers job restart.
 		// NOTE: Job fails and retries after reaching backoff limit.
-		BackoffLimit:            ptr.To(int32(3)),
-		ActiveDeadlineSeconds:   ptr.To(int64(60 * 60)),
-		TTLSecondsAfterFinished: ptr.To(int32(60 * 60)),
+		BackoffLimit:          ptr.To(int32(3)),
+		ActiveDeadlineSeconds: ptr.To(int64(60 * 60)),
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: j.labeller.GetInitJobObjectMeta(),
 			Spec: corev1.PodSpec{
@@ -314,6 +315,7 @@ func (j *InitJob) start(ctx context.Context, dry bool, isRestarted bool) (Compon
 	if _, err := j.configs.Build(); err != nil {
 		return ComponentStatusWaitingFor("job %v configmap %v", j.Name(), j.configs.GetConfigMapName()), err
 	}
+
 	// NOTE: Track job reason in configmap annotation but not recreate to allow manual fixes for failing job.
 	if isRestarted || !j.configs.Exists() || j.configs.getAnnotation(consts.InitJobReasonAnnotationName) != j.reason {
 		j.configs.setAnnotation(consts.InitJobReasonAnnotationName, j.reason)
@@ -339,12 +341,14 @@ func (j *InitJob) start(ctx context.Context, dry bool, isRestarted bool) (Compon
 func (j *InitJob) Sync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	condition := j.owner.GetStatusCondition(j.statusCondition)
 	isCompleted := condition != nil && condition.Reason == j.reason && condition.Status == metav1.ConditionTrue
-	if isCompleted {
+	isExists := j.Exists()
+	if isExists && isCompleted {
+		// NOTE: Not checking init job status to allow manual setting condition to "True".
 		return ComponentStatusReadyAfter("Job %v completed in %v", j.Name(), j.initJob.Duration()), nil
 	}
 
 	isStarted := condition != nil && condition.Reason == j.reason
-	if !j.Exists() || !isStarted || j.initJob.IsFailed() {
+	if !isExists || !isStarted || j.initJob.IsFailed() {
 		isRestarted := condition == nil
 		return j.start(ctx, dry, isRestarted)
 	}

--- a/pkg/components/scheduler.go
+++ b/pkg/components/scheduler.go
@@ -151,7 +151,7 @@ func (s *Scheduler) Sync(ctx context.Context, dry bool) (ComponentStatus, error)
 		return status, err
 	}
 
-	if s.ytsaurus.IsInitializing() || s.ytsaurus.IsReadyToWork() {
+	if s.ytsaurus.IsReadyForInitJobs() && !s.initOpArchiveJob.IsCompleted() {
 		if status, err := s.initOpArchive(ctx, dry); !status.IsReady() || err != nil {
 			return status, err
 		}
@@ -161,7 +161,7 @@ func (s *Scheduler) Sync(ctx context.Context, dry bool) (ComponentStatus, error)
 }
 
 func (s *Scheduler) initOpArchive(ctx context.Context, dry bool) (ComponentStatus, error) {
-	if len(s.tabletNodes) == 0 || s.initOpArchiveJob.IsCompleted() {
+	if len(s.tabletNodes) == 0 {
 		return ComponentStatusReady(), nil
 	}
 

--- a/pkg/components/yql_agent.go
+++ b/pkg/components/yql_agent.go
@@ -221,7 +221,7 @@ func (yqla *YqlAgent) Sync(ctx context.Context, dry bool) (ComponentStatus, erro
 		return ComponentStatusWaitingFor(yqla.execSecret.Name()), err
 	}
 
-	if (yqla.ytsaurus.IsInitializing() || yqla.ytsaurus.IsReadyToWork()) && !yqla.initEnvironment.IsCompleted() {
+	if yqla.ytsaurus.IsReadyForInitJobs() && !yqla.initEnvironment.IsCompleted() {
 		if status, err := yqla.initEnvironment.RunScript(ctx, dry, "YQLAgentInit", yqla.createInitScript(), nil); err != nil || !status.IsReady() {
 			return status, err
 		}

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/Job yt-client-init-job-user.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-client-init-job-user-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/Job yt-master-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/Job yt-master-init-job-default.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-master-init-job-default-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/Job yt-client-init-job-user.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-client-init-job-user-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/Job yt-master-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/Job yt-master-init-job-default.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-master-init-job-default-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/Job yt-client-init-job-user.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-client-init-job-user-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/Job yt-master-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/Job yt-master-init-job-default.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-master-init-job-default-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler Minimal Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/Job yt-client-init-job-user.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-client-init-job-user-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler Minimal Test/Job yt-master-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/Job yt-master-init-job-default.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-master-init-job-default-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Job yt-chyt-test-ytsaurus-init-job-release.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Job yt-chyt-test-ytsaurus-init-job-release.yaml
@@ -76,7 +76,6 @@ spec:
           defaultMode: 320
           name: yt-chyt-test-ytsaurus-init-job-release-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Job yt-chyt-test-ytsaurus-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Job yt-chyt-test-ytsaurus-init-job-user.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-chyt-test-ytsaurus-init-job-user-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Job yt-client-init-job-user.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-client-init-job-user-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Job yt-master-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Job yt-master-init-job-default.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-master-init-job-default-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Job yt-client-init-job-user.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-client-init-job-user-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Job yt-master-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Job yt-master-init-job-default.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-master-init-job-default-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Job yt-client-init-job-user.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-client-init-job-user-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Job yt-master-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Job yt-master-init-job-default.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-master-init-job-default-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Job yt-client-init-job-user.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-client-init-job-user-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Job yt-master-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Job yt-master-init-job-default.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-master-init-job-default-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Job yt-client-init-job-user.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-client-init-job-user-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Job yt-master-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Job yt-master-init-job-default.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-master-init-job-default-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/Job yt-client-init-job-user.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-client-init-job-user-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/Job yt-master-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/Job yt-master-init-job-default.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-master-init-job-default-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With SPYT Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/Job yt-client-init-job-user.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-client-init-job-user-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With SPYT Test/Job yt-master-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/Job yt-master-init-job-default.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-master-init-job-default-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With SPYT Test/Job yt-spyt-test-ytsaurus-init-job-spyt-environment.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/Job yt-spyt-test-ytsaurus-init-job-spyt-environment.yaml
@@ -77,7 +77,6 @@ spec:
           defaultMode: 320
           name: yt-spyt-test-ytsaurus-init-job-spyt-environment-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With SPYT Test/Job yt-spyt-test-ytsaurus-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/Job yt-spyt-test-ytsaurus-init-job-user.yaml
@@ -71,7 +71,6 @@ spec:
           defaultMode: 320
           name: yt-spyt-test-ytsaurus-init-job-user-config
         name: init-script
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-client-init-job-user.yaml
@@ -114,7 +114,6 @@ spec:
       - name: bus-client-secret
         secret:
           secretName: native-client-cert
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-master-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-master-init-job-default.yaml
@@ -113,7 +113,6 @@ spec:
       - name: bus-client-secret
         secret:
           secretName: native-client-cert
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-strawberry-controller-init-job-cluster.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-strawberry-controller-init-job-cluster.yaml
@@ -117,7 +117,6 @@ spec:
       - name: bus-client-secret
         secret:
           secretName: native-client-cert
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-strawberry-controller-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-strawberry-controller-init-job-user.yaml
@@ -114,7 +114,6 @@ spec:
       - name: bus-client-secret
         secret:
           secretName: native-client-cert
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-ui-init-job-default.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-ui-init-job-default.yaml
@@ -114,7 +114,6 @@ spec:
       - name: bus-client-secret
         secret:
           secretName: native-client-cert
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-yql-agent-init-job-yql-agent-environment.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-yql-agent-init-job-yql-agent-environment.yaml
@@ -114,7 +114,6 @@ spec:
       - name: bus-client-secret
         secret:
           secretName: native-client-cert
-  ttlSecondsAfterFinished: 3600
 status:
   conditions:
   - lastProbeTime: null


### PR DESCRIPTION
This must be allowed during initialization and all ready-to-update states,
because restart itself switches cluster into reconfiguration.

Do not remove init jobs automatically, because this triggers init job restart.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
