### PR TITLE
Remove default insecure admin password and token

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -978,6 +978,8 @@ type YtsaurusSpec struct {
 	//+optional
 	RequiresOperatorVersion string `json:"requiresOperatorVersion,omitempty"`
 
+	// Reference to secret with initial "login", "password", "token" for administrator user.
+	// If secret is not specified or does not exist default admin/password is no longer set.
 	AdminCredentials *corev1.LocalObjectReference `json:"adminCredentials,omitempty"`
 
 	OauthService *OauthServiceSpec `json:"oauthService,omitempty"`

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -57,8 +57,8 @@ spec:
             description: YtsaurusSpec defines the desired state of Ytsaurus
             properties:
               adminCredentials:
-                description: LocalObjectReference contains enough information to let
-                  you locate the...
+                description: Reference to secret with initial "login", "password",
+                  "token" for administrator...
                 properties:
                   name:
                     default: ""

--- a/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
@@ -18,7 +18,7 @@
       "type": "object",
       "properties": {
         "adminCredentials": {
-          "description": "LocalObjectReference contains enough information to let you locate the...",
+          "description": "Reference to secret with initial \"login\", \"password\", \"token\" for administrator...",
           "type": "object",
           "properties": {
             "name": {

--- a/config/samples/cluster_v1_cri.yaml
+++ b/config/samples/cluster_v1_cri.yaml
@@ -33,9 +33,9 @@ spec:
   # https://github.com/ytsaurus/ytsaurus-ui/
   uiImage: ghcr.io/ytsaurus/ui:stable
 
-  # Default "admin" password and token is "password".
-  # adminCredentials:
-  #  name: admin-credentials
+  # Secret with login, password and token for administrator.
+  adminCredentials:
+    name: ytsaurus-admin-credentials
 
   # configOverrides:
   #  name: ytsaurus-config-overrides
@@ -508,7 +508,17 @@ spec:
         memory: 100Mi
 
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ytsaurus-admin-credentials
+type: Opaque
+data:
+  login: YWRtaW4=         # admin
+  password: cGFzc3dvcmQ=  # password
+  token: cGFzc3dvcmQ=     # password
 
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/config/samples/cluster_v1_demo.yaml
+++ b/config/samples/cluster_v1_demo.yaml
@@ -15,6 +15,7 @@ spec:
 
   uiImage: ghcr.io/ytsaurus/ui:stable
 
+  # Secret with login, password and token for administrator.
   adminCredentials:
     name: ytadminsec
 
@@ -142,3 +143,14 @@ spec:
     resources:
       limits:
         memory: 100Mi
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ytadminsec
+type: Opaque
+data:
+  login: YWRtaW4=         # admin
+  password: cGFzc3dvcmQ=  # password
+  token: cGFzc3dvcmQ=     # password

--- a/config/samples/cluster_v1_tls.yaml
+++ b/config/samples/cluster_v1_tls.yaml
@@ -44,7 +44,7 @@ spec:
   # https://github.com/ytsaurus/ytsaurus-ui/
   uiImage: ghcr.io/ytsaurus/ui:stable
 
-  # Default "admin" password and token is "password".
+  # Secret with login, password and token for administrator.
   adminCredentials:
     name: ytsaurus-admin-credentials
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -3309,7 +3309,7 @@ _Appears in:_
 | `dnsConfig` _[PodDNSConfig](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#poddnsconfig-v1-core)_ | DNSConfig allows customizing the DNS settings. |  |  |
 | `uiImage` _string_ |  |  |  |
 | `requiresOperatorVersion` _string_ | requiresOperatorVersion is used to lock the YT spec to an Operator version or range.<br />Syntax: https://github.com/Masterminds/semver<br />Example: "~0.1.2" is equivalent to ">= 0.1.2, < 0.2.0". |  |  |
-| `adminCredentials` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ |  |  |  |
+| `adminCredentials` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | Reference to secret with initial "login", "password", "token" for administrator user.<br />If secret is not specified or does not exist default admin/password is no longer set. |  |  |
 | `oauthService` _[OauthServiceSpec](#oauthservicespec)_ |  |  |  |
 | `isManaged` _boolean_ | Setting to false disables all operator actions. Default: true. | true |  |
 | `updatePlan` _[ComponentUpdateSelector](#componentupdateselector) array_ | Defines components which are allowed to update.<br />Can contain either single "class" item or several "component" items.<br />When empty: update nothing |  |  |

--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -161,31 +161,21 @@ func (m *Master) ArePodsReady(ctx context.Context) (ComponentStatus, error) {
 	return arePodsReady(ctx, m.server, m.labeller, []string{consts.YTServerContainerName})
 }
 
-func (m *Master) getAdminCredentials() (adminLogin string, adminPassword string, adminToken string) {
-	adminLogin, adminPassword = consts.DefaultAdminLogin, consts.DefaultAdminPassword
-	adminToken = consts.DefaultAdminPassword
-
+func (m *Master) getAdminCredentials() (exists bool, adminLogin string, adminPassword string, adminToken string) {
 	if m.adminCredentials.Name != "" {
-		value, ok := m.adminCredentials.Data[consts.AdminLoginSecret]
-		if ok {
-			adminLogin = string(value)
-		}
-		value, ok = m.adminCredentials.Data[consts.AdminPasswordSecret]
-		if ok {
-			adminPassword = string(value)
-		}
-
-		value, ok = m.adminCredentials.Data[consts.AdminTokenSecret]
-		if ok {
-			adminToken = string(value)
-		}
+		adminLogin = string(m.adminCredentials.Data[consts.AdminLoginSecretKey])
+		adminPassword = string(m.adminCredentials.Data[consts.AdminPasswordSecretKey])
+		adminToken = string(m.adminCredentials.Data[consts.AdminTokenSecretKey])
+		exists = adminLogin != "" && adminPassword != "" && adminToken != ""
 	}
-	return adminLogin, adminPassword, adminToken
+	return exists, adminLogin, adminPassword, adminToken
 }
 
 func (m *Master) initAdminUser() string {
-	adminLogin, adminPassword, adminToken := m.getAdminCredentials()
-
+	exists, adminLogin, adminPassword, adminToken := m.getAdminCredentials()
+	if !exists {
+		return ""
+	}
 	commands := createUserCommand(adminLogin, adminPassword, adminToken, true)
 	return RunIfNonexistent(fmt.Sprintf("//sys/users/%s", adminLogin), commands...)
 }

--- a/pkg/consts/defaults.go
+++ b/pkg/consts/defaults.go
@@ -4,15 +4,12 @@ import (
 	"time"
 )
 
-const DefaultAdminLogin = "admin"
-const DefaultAdminPassword = "password"
-
 const RandomTokenPrefix = "ytct-ytop-"
 const RandomTokenBytes = 30
 
-const AdminLoginSecret = "login"
-const AdminPasswordSecret = "password"
-const AdminTokenSecret = "token"
+const AdminLoginSecretKey = "login"
+const AdminPasswordSecretKey = "password"
+const AdminTokenSecretKey = "token"
 
 const DefaultCABundlePath = "/etc/ssl/certs/ca-certificates.crt"
 

--- a/pkg/testutil/builders.go
+++ b/pkg/testutil/builders.go
@@ -8,6 +8,10 @@ import (
 )
 
 const (
+	AdminLogin    = "admin"
+	AdminPassword = "admin-password"
+	AdminToken    = "admin-token"
+
 	testYtsaurusImage = "test-ytsaurus-image"
 	dndsNameOne       = "dn-1"
 )

--- a/pkg/testutil/spec_builders.go
+++ b/pkg/testutil/spec_builders.go
@@ -13,6 +13,7 @@ import (
 
 	"k8s.io/utils/ptr"
 
+	"github.com/ytsaurus/ytsaurus-k8s-operator/pkg/consts"
 	"github.com/ytsaurus/ytsaurus-k8s-operator/pkg/version"
 
 	ytv1 "github.com/ytsaurus/ytsaurus-k8s-operator/api/v1"
@@ -29,6 +30,8 @@ const (
 	// <...> is too long (64 characters is the max, 67 characters requested)`.
 	// FIXME(khlebnikov): https://github.com/ytsaurus/ytsaurus-k8s-operator/issues/390
 	RemoteResourceName = "rmt"
+
+	YtsaurusAdminSecret = "test-ytsaurus-admin" //nolint:gosec //secret
 )
 
 type YtsaurusImages struct {
@@ -224,6 +227,8 @@ type YtsaurusBuilder struct {
 	WithRPCProxyTLS    bool
 
 	ImagePullSecret *corev1.LocalObjectReference
+
+	YtsaurusAdminSecret *corev1.Secret
 }
 
 func (b *YtsaurusBuilder) CreateVolumeClaim(name string, size resource.Quantity) ytv1.EmbeddedPersistentVolumeClaim {
@@ -309,6 +314,24 @@ func (b *YtsaurusBuilder) CreateMinimal() {
 			HTTPProxies: []ytv1.HTTPProxiesSpec{
 				b.CreateHTTPProxiesSpec(),
 			},
+		},
+	}
+}
+
+func (b *YtsaurusBuilder) WithAdminUser() {
+	b.Ytsaurus.Spec.AdminCredentials = &corev1.LocalObjectReference{
+		Name: YtsaurusAdminSecret,
+	}
+	b.YtsaurusAdminSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      YtsaurusAdminSecret,
+			Namespace: b.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			consts.AdminLoginSecretKey:    []byte(AdminLogin),
+			consts.AdminPasswordSecretKey: []byte(AdminPassword),
+			consts.AdminTokenSecretKey:    []byte(AdminToken),
 		},
 	}
 }

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -33,6 +33,7 @@ import (
 	ytv1 "github.com/ytsaurus/ytsaurus-k8s-operator/api/v1"
 
 	"github.com/ytsaurus/ytsaurus-k8s-operator/pkg/consts"
+	"github.com/ytsaurus/ytsaurus-k8s-operator/pkg/testutil"
 
 	"go.ytsaurus.tech/yt/go/guid"
 	"go.ytsaurus.tech/yt/go/ypath"
@@ -531,7 +532,7 @@ func queryClickHouse(ctx context.Context, httpClient *http.Client, ytProxyAddres
 	if err != nil {
 		return "", err
 	}
-	request.Header.Add("Authorization", "OAuth "+consts.DefaultAdminPassword)
+	request.Header.Add("Authorization", "OAuth "+testutil.AdminToken)
 
 	response, err := httpClient.Do(request)
 	if err != nil {

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -70,7 +70,7 @@ const (
 func getYtClient(httpClient *http.Client, proxyAddress string) yt.Client {
 	ytClient, err := ythttp.NewClient(&yt.Config{
 		Proxy:                 proxyAddress,
-		Token:                 consts.DefaultAdminPassword,
+		Token:                 testutil.AdminToken,
 		LightRequestTimeout:   ptr.To(lightRequestTimeout),
 		CompressionCodec:      yt.ClientCodecNone,
 		DisableProxyDiscovery: true,
@@ -85,7 +85,7 @@ func getYtRPCClient(httpClient *http.Client, proxyAddress, rpcProxyAddress strin
 	ytClient, err := ytrpc.NewClient(&yt.Config{
 		Proxy:                 proxyAddress,
 		RPCProxy:              rpcProxyAddress,
-		Token:                 consts.DefaultAdminPassword,
+		Token:                 testutil.AdminToken,
 		DisableProxyDiscovery: true,
 		Logger:                ytLogger,
 		HTTPClient:            httpClient,
@@ -318,13 +318,14 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 			Namespace: namespace,
 		}
 		ytBuilder.CreateMinimal()
+		ytBuilder.WithAdminUser()
 		ytsaurus = ytBuilder.Ytsaurus
 
 		By("Enabling image heater")
 		ytsaurus.Spec.ClusterFeatures.EnableImageHeater = true
 
 		imagePullSecrets = nil
-		objects = []client.Object{ytsaurus}
+		objects = []client.Object{ytsaurus, ytBuilder.YtsaurusAdminSecret}
 
 		By("Tracking Ytsaurus updates")
 		DeferCleanup(TrackObjectUpdates(specCtx, ytsaurus, &ytv1.YtsaurusList{}, NewYtsaurusStatusTracker()))
@@ -517,7 +518,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				// NOTE: WhoAmI right now does not retry.
 				Eventually(ctx, func(ctx context.Context) (*yt.WhoAmIResult, error) {
 					return ytClient.WhoAmI(ctx, nil)
-				}).To(HaveField("Login", consts.DefaultAdminLogin))
+				}).To(HaveField("Login", testutil.AdminLogin))
 			})
 		}
 
@@ -535,7 +536,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				// NOTE: WhoAmI right now does not retry.
 				Eventually(ctx, func(ctx context.Context) (*yt.WhoAmIResult, error) {
 					return ytClientHTTPS.WhoAmI(ctx, nil)
-				}).To(HaveField("Login", consts.DefaultAdminLogin))
+				}).To(HaveField("Login", testutil.AdminLogin))
 			})
 
 			if ytBuilder.WithHTTPSOnlyProxy {
@@ -545,15 +546,15 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 		}
 
 		DeferCleanup(AttachProgressReporter(func() string {
-			return fmt.Sprintf("YT_PROXY=%s YT_TOKEN=%s", ytProxyAddress, consts.DefaultAdminPassword)
+			return fmt.Sprintf("YT_PROXY=%s YT_TOKEN=%s", ytProxyAddress, testutil.AdminToken)
 		}))
 
 		log.Info("Ytsaurus access",
 			"YT_PROXY", ytProxyAddress,
 			"YT_PROXY HTTPS", ytProxyAddressHTTPS,
-			"YT_TOKEN", consts.DefaultAdminPassword,
-			"login", consts.DefaultAdminLogin,
-			"password", consts.DefaultAdminPassword,
+			"YT_TOKEN", testutil.AdminToken,
+			"login", testutil.AdminLogin,
+			"password", testutil.AdminPassword,
 		)
 
 		checkClusterHealth(ctx, ytClient)
@@ -600,7 +601,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 			Proxy:                    ytProxyAddressHTTPS,
 			RPCProxy:                 ytRPCProxyAddress,
 			CertificateAuthorityData: caBundleCertificates,
-			Token:                    consts.DefaultAdminPassword,
+			Token:                    testutil.AdminToken,
 			DisableProxyDiscovery:    true,
 			Logger:                   ytLogger,
 			HTTPClient:               httpClient,

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -118,14 +118,7 @@ data:
     if [ $(/usr/bin/yt exists //sys/@provision_lock) = 'true' ]; then
     /usr/bin/yt set //sys/@cluster_name 'test-ytsaurus'
     fi
-    if [ $(/usr/bin/yt exists //sys/users/admin) = 'false' ]; then
-    /usr/bin/yt create user --attributes '{name="admin"}' --ignore-existing
-    /usr/bin/yt execute set_user_password '{user=admin;new_password_sha256="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"}'
-    /usr/bin/yt create map_node '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8' --ignore-existing
-    /usr/bin/yt set '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8/@user' 'admin'
-    /usr/bin/yt add-member admin superusers || true
-    while [ "$(/usr/bin/yt check-permission --format json admin administer /)" != '{"action":"allow"}' ] ; do sleep 1 ; done
-    fi
+
 
     fi
 

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -216,14 +216,7 @@ data:
     if [ $(/usr/bin/yt exists //sys/@provision_lock) = 'true' ]; then
     /usr/bin/yt set //sys/@cluster_name 'test-ytsaurus'
     fi
-    if [ $(/usr/bin/yt exists //sys/users/admin) = 'false' ]; then
-    /usr/bin/yt create user --attributes '{name="admin"}' --ignore-existing
-    /usr/bin/yt execute set_user_password '{user=admin;new_password_sha256="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"}'
-    /usr/bin/yt create map_node '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8' --ignore-existing
-    /usr/bin/yt set '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8/@user' 'admin'
-    /usr/bin/yt add-member admin superusers || true
-    while [ "$(/usr/bin/yt check-permission --format json admin administer /)" != '{"action":"allow"}' ] ; do sleep 1 ; done
-    fi
+
 
     fi
 

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -152,14 +152,7 @@ data:
     if [ $(/usr/bin/yt exists //sys/@provision_lock) = 'true' ]; then
     /usr/bin/yt set //sys/@cluster_name 'test-ytsaurus'
     fi
-    if [ $(/usr/bin/yt exists //sys/users/admin) = 'false' ]; then
-    /usr/bin/yt create user --attributes '{name="admin"}' --ignore-existing
-    /usr/bin/yt execute set_user_password '{user=admin;new_password_sha256="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"}'
-    /usr/bin/yt create map_node '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8' --ignore-existing
-    /usr/bin/yt set '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8/@user' 'admin'
-    /usr/bin/yt add-member admin superusers || true
-    while [ "$(/usr/bin/yt check-permission --format json admin administer /)" != '{"action":"allow"}' ] ; do sleep 1 ; done
-    fi
+
 
     fi
 

--- a/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -118,14 +118,7 @@ data:
     if [ $(/usr/bin/yt exists //sys/@provision_lock) = 'true' ]; then
     /usr/bin/yt set //sys/@cluster_name 'test-ytsaurus'
     fi
-    if [ $(/usr/bin/yt exists //sys/users/admin) = 'false' ]; then
-    /usr/bin/yt create user --attributes '{name="admin"}' --ignore-existing
-    /usr/bin/yt execute set_user_password '{user=admin;new_password_sha256="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"}'
-    /usr/bin/yt create map_node '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8' --ignore-existing
-    /usr/bin/yt set '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8/@user' 'admin'
-    /usr/bin/yt add-member admin superusers || true
-    while [ "$(/usr/bin/yt check-permission --format json admin administer /)" != '{"action":"allow"}' ] ; do sleep 1 ; done
-    fi
+
 
     fi
 

--- a/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -118,14 +118,7 @@ data:
     if [ $(/usr/bin/yt exists //sys/@provision_lock) = 'true' ]; then
     /usr/bin/yt set //sys/@cluster_name 'test-ytsaurus'
     fi
-    if [ $(/usr/bin/yt exists //sys/users/admin) = 'false' ]; then
-    /usr/bin/yt create user --attributes '{name="admin"}' --ignore-existing
-    /usr/bin/yt execute set_user_password '{user=admin;new_password_sha256="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"}'
-    /usr/bin/yt create map_node '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8' --ignore-existing
-    /usr/bin/yt set '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8/@user' 'admin'
-    /usr/bin/yt add-member admin superusers || true
-    while [ "$(/usr/bin/yt check-permission --format json admin administer /)" != '{"action":"allow"}' ] ; do sleep 1 ; done
-    fi
+
 
     fi
 

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -118,14 +118,7 @@ data:
     if [ $(/usr/bin/yt exists //sys/@provision_lock) = 'true' ]; then
     /usr/bin/yt set //sys/@cluster_name 'test-ytsaurus'
     fi
-    if [ $(/usr/bin/yt exists //sys/users/admin) = 'false' ]; then
-    /usr/bin/yt create user --attributes '{name="admin"}' --ignore-existing
-    /usr/bin/yt execute set_user_password '{user=admin;new_password_sha256="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"}'
-    /usr/bin/yt create map_node '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8' --ignore-existing
-    /usr/bin/yt set '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8/@user' 'admin'
-    /usr/bin/yt add-member admin superusers || true
-    while [ "$(/usr/bin/yt check-permission --format json admin administer /)" != '{"action":"allow"}' ] ; do sleep 1 ; done
-    fi
+
 
     fi
 

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -118,14 +118,7 @@ data:
     if [ $(/usr/bin/yt exists //sys/@provision_lock) = 'true' ]; then
     /usr/bin/yt set //sys/@cluster_name 'test-ytsaurus'
     fi
-    if [ $(/usr/bin/yt exists //sys/users/admin) = 'false' ]; then
-    /usr/bin/yt create user --attributes '{name="admin"}' --ignore-existing
-    /usr/bin/yt execute set_user_password '{user=admin;new_password_sha256="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"}'
-    /usr/bin/yt create map_node '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8' --ignore-existing
-    /usr/bin/yt set '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8/@user' 'admin'
-    /usr/bin/yt add-member admin superusers || true
-    while [ "$(/usr/bin/yt check-permission --format json admin administer /)" != '{"action":"allow"}' ] ; do sleep 1 ; done
-    fi
+
 
     fi
 

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -118,14 +118,7 @@ data:
     if [ $(/usr/bin/yt exists //sys/@provision_lock) = 'true' ]; then
     /usr/bin/yt set //sys/@cluster_name 'test-ytsaurus'
     fi
-    if [ $(/usr/bin/yt exists //sys/users/admin) = 'false' ]; then
-    /usr/bin/yt create user --attributes '{name="admin"}' --ignore-existing
-    /usr/bin/yt execute set_user_password '{user=admin;new_password_sha256="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"}'
-    /usr/bin/yt create map_node '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8' --ignore-existing
-    /usr/bin/yt set '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8/@user' 'admin'
-    /usr/bin/yt add-member admin superusers || true
-    while [ "$(/usr/bin/yt check-permission --format json admin administer /)" != '{"action":"allow"}' ] ; do sleep 1 ; done
-    fi
+
 
     fi
 

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -118,14 +118,7 @@ data:
     if [ $(/usr/bin/yt exists //sys/@provision_lock) = 'true' ]; then
     /usr/bin/yt set //sys/@cluster_name 'test-ytsaurus'
     fi
-    if [ $(/usr/bin/yt exists //sys/users/admin) = 'false' ]; then
-    /usr/bin/yt create user --attributes '{name="admin"}' --ignore-existing
-    /usr/bin/yt execute set_user_password '{user=admin;new_password_sha256="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"}'
-    /usr/bin/yt create map_node '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8' --ignore-existing
-    /usr/bin/yt set '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8/@user' 'admin'
-    /usr/bin/yt add-member admin superusers || true
-    while [ "$(/usr/bin/yt check-permission --format json admin administer /)" != '{"action":"allow"}' ] ; do sleep 1 ; done
-    fi
+
 
     fi
 

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -118,14 +118,7 @@ data:
     if [ $(/usr/bin/yt exists //sys/@provision_lock) = 'true' ]; then
     /usr/bin/yt set //sys/@cluster_name 'test-ytsaurus'
     fi
-    if [ $(/usr/bin/yt exists //sys/users/admin) = 'false' ]; then
-    /usr/bin/yt create user --attributes '{name="admin"}' --ignore-existing
-    /usr/bin/yt execute set_user_password '{user=admin;new_password_sha256="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"}'
-    /usr/bin/yt create map_node '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8' --ignore-existing
-    /usr/bin/yt set '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8/@user' 'admin'
-    /usr/bin/yt add-member admin superusers || true
-    while [ "$(/usr/bin/yt check-permission --format json admin administer /)" != '{"action":"allow"}' ] ; do sleep 1 ; done
-    fi
+
 
     fi
 

--- a/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -118,14 +118,7 @@ data:
     if [ $(/usr/bin/yt exists //sys/@provision_lock) = 'true' ]; then
     /usr/bin/yt set //sys/@cluster_name 'test-ytsaurus'
     fi
-    if [ $(/usr/bin/yt exists //sys/users/admin) = 'false' ]; then
-    /usr/bin/yt create user --attributes '{name="admin"}' --ignore-existing
-    /usr/bin/yt execute set_user_password '{user=admin;new_password_sha256="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"}'
-    /usr/bin/yt create map_node '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8' --ignore-existing
-    /usr/bin/yt set '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8/@user' 'admin'
-    /usr/bin/yt add-member admin superusers || true
-    while [ "$(/usr/bin/yt check-permission --format json admin administer /)" != '{"action":"allow"}' ] ; do sleep 1 ; done
-    fi
+
 
     fi
 

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -186,9 +186,9 @@ data:
     fi
     if [ $(/usr/bin/yt exists //sys/users/admin) = 'false' ]; then
     /usr/bin/yt create user --attributes '{name="admin"}' --ignore-existing
-    /usr/bin/yt execute set_user_password '{user=admin;new_password_sha256="5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8"}'
-    /usr/bin/yt create map_node '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8' --ignore-existing
-    /usr/bin/yt set '//sys/cypress_tokens/5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8/@user' 'admin'
+    /usr/bin/yt execute set_user_password '{user=admin;new_password_sha256="8e70fdbd0400b7a21539fd15fb4ab86c129f7cbd99261dbb0d95c18df8dec177"}'
+    /usr/bin/yt create map_node '//sys/cypress_tokens/10a4c7c9fc5206d6f36dc6944a81bb6f4a3cb0e25014ae3b12e6c3e52712292a' --ignore-existing
+    /usr/bin/yt set '//sys/cypress_tokens/10a4c7c9fc5206d6f36dc6944a81bb6f4a3cb0e25014ae3b12e6c3e52712292a/@user' 'admin'
     /usr/bin/yt add-member admin superusers || true
     while [ "$(/usr/bin/yt check-permission --format json admin administer /)" != '{"action":"allow"}' ] ; do sleep 1 ; done
     fi

--- a/test/r8r/canondata/Components reconciler With all components Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Object List.yaml
@@ -711,6 +711,11 @@
   name: test-overrides
   namespace: ytsaurus-components
   resourceVersion: "1"
+- creationTimestamp: null
+  generation: 1
+  name: test-ytsaurus-admin
+  namespace: ytsaurus-components
+  resourceVersion: "1"
 - annotations:
     extra-pod-annotation: "true"
     ytsaurus.tech/observed-generation: "1"

--- a/test/r8r/canondata/Components reconciler With all components Test/Secret test-ytsaurus-admin.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Secret test-ytsaurus-admin.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  login: YWRtaW4=
+  password: YWRtaW4tcGFzc3dvcmQ=
+  token: YWRtaW4tdG9rZW4=
+kind: Secret
+metadata:
+  creationTimestamp: null
+  generation: 1
+  name: test-ytsaurus-admin
+  namespace: ytsaurus-components
+  resourceVersion: "1"
+type: Opaque

--- a/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
@@ -7,6 +7,8 @@ metadata:
   namespace: ytsaurus-components
   resourceVersion: "18"
 spec:
+  adminCredentials:
+    name: test-ytsaurus-admin
   caBundle:
     name: ytsaurus-dev-ca.crt
   caRootBundle:

--- a/test/r8r/components_test.go
+++ b/test/r8r/components_test.go
@@ -299,6 +299,9 @@ var _ = Describe("Components reconciler", Label("reconciler"), func() {
 			if ytBuilder.Overrides != nil {
 				Expect(k8sClient.Create(ctx, ytBuilder.Overrides)).To(Succeed())
 			}
+			if ytBuilder.YtsaurusAdminSecret != nil {
+				Expect(k8sClient.Create(ctx, ytBuilder.YtsaurusAdminSecret)).To(Succeed())
+			}
 			Expect(k8sClient.Create(ctx, ytsaurus)).To(Succeed())
 			controllerObjects = append(controllerObjects, ytsaurus)
 		})
@@ -650,6 +653,7 @@ var _ = Describe("Components reconciler", Label("reconciler"), func() {
 
 	Context("With all components", func() {
 		BeforeEach(func() {
+			ytBuilder.WithAdminUser()
 			ytBuilder.WithOverrides()
 			ytBuilder.WithSecondaryMaster()
 			ytBuilder.WithMasterCaches()

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -62,8 +62,8 @@ spec:
             description: YtsaurusSpec defines the desired state of Ytsaurus
             properties:
               adminCredentials:
-                description: LocalObjectReference contains enough information to let
-                  you locate the...
+                description: Reference to secret with initial "login", "password",
+                  "token" for administrator...
                 properties:
                   name:
                     default: ""


### PR DESCRIPTION
Do not create admin user when credentials are not specified.
Could be done any time using operator token or inside master pod.

Issue: #813
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
