### PR TITLE
Start caches/discovery/tablets after master [1]

### DIFF
--- a/controllers/component_manager.go
+++ b/controllers/component_manager.go
@@ -99,7 +99,7 @@ func NewComponentManager(
 	yc := components.NewYtsaurusClient(cfgen, ytsaurus, m, hps[0], getAllComponents)
 	allComponents = append(allComponents, yc)
 
-	d := components.NewDiscovery(cfgen, ytsaurus, yc)
+	d := components.NewDiscovery(cfgen, ytsaurus, yc, m)
 	allComponents = append(allComponents, d)
 
 	var dnds []components.Component

--- a/controllers/component_manager.go
+++ b/controllers/component_manager.go
@@ -185,7 +185,7 @@ func NewComponentManager(
 	}
 
 	if resource.Spec.MasterCaches != nil {
-		mc := components.NewMasterCache(cfgen, ytsaurus, yc)
+		mc := components.NewMasterCache(cfgen, ytsaurus, yc, m)
 		allComponents = append(allComponents, mc)
 	}
 

--- a/controllers/component_manager.go
+++ b/controllers/component_manager.go
@@ -146,7 +146,7 @@ func NewComponentManager(
 	var tnds []components.Component
 	if len(resource.Spec.TabletNodes) > 0 {
 		for idx, tndSpec := range resource.Spec.TabletNodes {
-			tnds = append(tnds, components.NewTabletNode(nodeCfgGen, ytsaurus, yc, tndSpec, idx == 0))
+			tnds = append(tnds, components.NewTabletNode(nodeCfgGen, ytsaurus, yc, m, tndSpec, idx == 0))
 		}
 	}
 	allComponents = append(allComponents, tnds...)

--- a/pkg/components/discovery.go
+++ b/pkg/components/discovery.go
@@ -19,9 +19,16 @@ type Discovery struct {
 
 	cfgen          *ytconfig.Generator
 	ytsaurusClient internalYtsaurusClient
+
+	master Component
 }
 
-func NewDiscovery(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus, yc internalYtsaurusClient) *Discovery {
+func NewDiscovery(
+	cfgen *ytconfig.Generator,
+	ytsaurus *apiproxy.Ytsaurus,
+	yc internalYtsaurusClient,
+	master Component,
+) *Discovery {
 	l := cfgen.GetComponentLabeller(consts.DiscoveryType, "")
 	resource := ytsaurus.GetResource()
 
@@ -47,6 +54,7 @@ func NewDiscovery(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus, yc int
 		serverComponent: newLocalServerComponent(l, ytsaurus, srv),
 		cfgen:           cfgen,
 		ytsaurusClient:  yc,
+		master:          master,
 	}
 }
 
@@ -64,6 +72,11 @@ func (d *Discovery) Sync(ctx context.Context, dry bool) (ComponentStatus, error)
 		if d.ytsaurus.GetUpdateState() != ytv1.UpdateStateWaitingForPodsCreation {
 			return ComponentStatusReady(), nil
 		}
+	}
+
+	// Do not start until masters are running, otherwise may cache incomplete ClusterMeta.
+	if masterStatus := d.master.GetStatus(); !masterStatus.IsRunning() {
+		return masterStatus.Blocker(), nil
 	}
 
 	if d.NeedSync() {

--- a/pkg/components/master_caches.go
+++ b/pkg/components/master_caches.go
@@ -17,9 +17,16 @@ type MasterCache struct {
 
 	cfgen          *ytconfig.Generator
 	ytsaurusClient internalYtsaurusClient
+
+	master Component
 }
 
-func NewMasterCache(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus, yc internalYtsaurusClient) *MasterCache {
+func NewMasterCache(
+	cfgen *ytconfig.Generator,
+	ytsaurus *apiproxy.Ytsaurus,
+	yc internalYtsaurusClient,
+	master Component,
+) *MasterCache {
 	l := cfgen.GetComponentLabeller(consts.MasterCacheType, "")
 
 	resource := ytsaurus.GetResource()
@@ -45,6 +52,7 @@ func NewMasterCache(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus, yc i
 		serverComponent: newLocalServerComponent(l, ytsaurus, srv),
 		cfgen:           cfgen,
 		ytsaurusClient:  yc,
+		master:          master,
 	}
 }
 
@@ -62,6 +70,11 @@ func (mc *MasterCache) Sync(ctx context.Context, dry bool) (ComponentStatus, err
 		if mc.ytsaurus.GetUpdateState() != ytv1.UpdateStateWaitingForPodsCreation {
 			return ComponentStatusReady(), nil
 		}
+	}
+
+	// Do not start until masters are running, otherwise may cache incomplete ClusterMeta.
+	if masterStatus := mc.master.GetStatus(); !masterStatus.IsRunning() {
+		return masterStatus.Blocker(), nil
 	}
 
 	if mc.NeedSync() {

--- a/pkg/components/tablet_node.go
+++ b/pkg/components/tablet_node.go
@@ -32,12 +32,15 @@ type TabletNode struct {
 	initBundlesCondition string
 	spec                 ytv1.TabletNodesSpec
 	doInitialization     bool
+
+	master Component
 }
 
 func NewTabletNode(
 	cfgen *ytconfig.NodeGenerator,
 	ytsaurus *apiproxy.Ytsaurus,
 	ytsaurusClient internalYtsaurusClient,
+	master Component,
 	spec ytv1.TabletNodesSpec,
 	doInitiailization bool,
 ) *TabletNode {
@@ -68,6 +71,7 @@ func NewTabletNode(
 		ytsaurusClient:       ytsaurusClient,
 		spec:                 spec,
 		doInitialization:     doInitiailization,
+		master:               master,
 	}
 }
 
@@ -88,6 +92,13 @@ func (tn *TabletNode) Sync(ctx context.Context, dry bool) (ComponentStatus, erro
 			}
 		} else {
 			return ComponentStatusReadyAfter("Not updating component"), nil
+		}
+	}
+
+	if tn.master != nil {
+		// Do not start until masters are running, otherwise may cache incomplete ClusterMeta.
+		if masterStatus := tn.master.GetStatus(); !masterStatus.IsRunning() {
+			return masterStatus.Blocker(), nil
 		}
 	}
 

--- a/pkg/components/tablet_node_test.go
+++ b/pkg/components/tablet_node_test.go
@@ -185,7 +185,7 @@ var _ = Describe("Tablet node test", func() {
 
 			ytsaurusClient.SetStatus(SimpleStatus(SyncStatusPending))
 
-			tabletNode := NewTabletNode(cfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], true)
+			tabletNode := NewTabletNode(cfgen, ytsaurus, ytsaurusClient, nil, ytsaurusSpec.Spec.TabletNodes[0], true)
 			tabletNode.server = NewFakeServer()
 
 			status, err := tabletNode.Sync(ctx, true)
@@ -204,7 +204,7 @@ var _ = Describe("Tablet node test", func() {
 			ytsaurus := apiproxy.NewYtsaurus(ytsaurusSpec, client, record.NewFakeRecorder(1), scheme)
 
 			ytsaurusClient := NewFakeYtsaurusClient(mockYtClient)
-			tabletNode := NewTabletNode(cfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], true)
+			tabletNode := NewTabletNode(cfgen, ytsaurus, ytsaurusClient, nil, ytsaurusSpec.Spec.TabletNodes[0], true)
 			fakeServer := NewFakeServer()
 			fakeServer.instanceCount = 1
 			tabletNode.server = fakeServer
@@ -231,7 +231,7 @@ var _ = Describe("Tablet node test", func() {
 			createCellNetError := net.UnknownNetworkError("create cell: some net error")
 
 			nodeCfgen := ytconfig.NewLocalNodeGenerator(ytsaurusSpec, ytsaurusSpec.Name, "cluster_domain")
-			tabletNode := NewTabletNode(nodeCfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], true)
+			tabletNode := NewTabletNode(nodeCfgen, ytsaurus, ytsaurusClient, nil, ytsaurusSpec.Spec.TabletNodes[0], true)
 			tabletNode.server = NewFakeServer()
 
 			By("Failed to check if there is //sys/tablet_cell_bundles/sys.")
@@ -537,7 +537,7 @@ var _ = Describe("Tablet node test", func() {
 			}
 
 			nodeCfgen := ytconfig.NewLocalNodeGenerator(ytsaurusSpec, ytsaurusSpec.Name, "cluster_domain")
-			tabletNode := NewTabletNode(nodeCfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], true)
+			tabletNode := NewTabletNode(nodeCfgen, ytsaurus, ytsaurusClient, nil, ytsaurusSpec.Spec.TabletNodes[0], true)
 			tabletNode.server = NewFakeServer()
 
 			status, err := tabletNode.Sync(ctx, false)
@@ -555,7 +555,7 @@ var _ = Describe("Tablet node test", func() {
 			ytsaurusClient := NewFakeYtsaurusClient(mockYtClient)
 
 			cfgen := ytconfig.NewLocalNodeGenerator(ytsaurusSpec, ytsaurusSpec.Name, "cluster_domain")
-			tabletNode := NewTabletNode(cfgen, ytsaurus, ytsaurusClient, ytsaurusSpec.Spec.TabletNodes[0], false)
+			tabletNode := NewTabletNode(cfgen, ytsaurus, ytsaurusClient, nil, ytsaurusSpec.Spec.TabletNodes[0], false)
 			tabletNode.server = NewFakeServer()
 
 			status, err := tabletNode.Sync(ctx, true)

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/Events.yaml
@@ -235,101 +235,6 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
-  message: Created YT object ds (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
-  message: Config ytserver-discovery.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
-  message: Created YT object discovery (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
     resourceVersion: "4"
   lastTimestamp: null
   message: Config client.yson needs creation
@@ -466,6 +371,101 @@
     resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "6"
+  lastTimestamp: null
+  message: Created YT object ds (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "6"
+  lastTimestamp: null
+  message: Config ytserver-discovery.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "6"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "6"
+  lastTimestamp: null
+  message: Created YT object discovery (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "6"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/Ytsaurus.yaml
@@ -103,12 +103,6 @@ status:
     status: "True"
     type: ImageHeaterReady
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 1, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: DiscoveryReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -120,6 +114,12 @@ status:
     reason: Ready
     status: "True"
     type: MasterReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 1, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DiscoveryReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 1, running 0, need 0'
     observedGeneration: 1

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/Events.yaml
@@ -386,101 +386,6 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object ds (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Config ytserver-discovery.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object discovery (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
     resourceVersion: "3"
   lastTimestamp: null
   message: Config client.yson needs creation
@@ -617,6 +522,101 @@
     resourceVersion: "5"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object ds (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Config ytserver-discovery.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object discovery (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/Ytsaurus.yaml
@@ -208,12 +208,6 @@ status:
     status: "True"
     type: Master-4Ready
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 1, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: DiscoveryReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -225,6 +219,12 @@ status:
     reason: Ready
     status: "True"
     type: MasterReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 1, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DiscoveryReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 1, running 0, need 0'
     observedGeneration: 1

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/Events.yaml
@@ -196,101 +196,6 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object ds (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Config ytserver-discovery.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object discovery (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
     resourceVersion: "3"
   lastTimestamp: null
   message: Config client.yson needs creation
@@ -427,6 +332,101 @@
     resourceVersion: "5"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object ds (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Config ytserver-discovery.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object discovery (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/Ytsaurus.yaml
@@ -133,12 +133,6 @@ status:
     status: "True"
     type: Master-2Ready
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 0, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: DiscoveryReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -150,6 +144,12 @@ status:
     reason: Ready
     status: "True"
     type: MasterReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 0, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DiscoveryReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 0, running 0, need 0'
     observedGeneration: 1

--- a/test/r8r/canondata/Components reconciler Minimal Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/Events.yaml
@@ -101,101 +101,6 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object ds (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Config ytserver-discovery.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object discovery (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
     resourceVersion: "3"
   lastTimestamp: null
   message: Config client.yson needs creation
@@ -332,6 +237,101 @@
     resourceVersion: "5"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object ds (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Config ytserver-discovery.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object discovery (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler Minimal Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/Ytsaurus.yaml
@@ -86,12 +86,6 @@ status:
     status: "True"
     type: OperatorVersion
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 1, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: DiscoveryReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -103,6 +97,12 @@ status:
     reason: Ready
     status: "True"
     type: MasterReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 1, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DiscoveryReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 1, running 0, need 0'
     observedGeneration: 1

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Events.yaml
@@ -101,101 +101,6 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object ds (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Config ytserver-discovery.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object discovery (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
     resourceVersion: "3"
   lastTimestamp: null
   message: Config client.yson needs creation
@@ -332,6 +237,101 @@
     resourceVersion: "5"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object ds (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Config ytserver-discovery.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object discovery (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Ytsaurus.yaml
@@ -86,12 +86,6 @@ status:
     status: "True"
     type: OperatorVersion
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 1, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: DiscoveryReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -103,6 +97,12 @@ status:
     reason: Ready
     status: "True"
     type: MasterReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 1, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DiscoveryReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 1, running 0, need 0'
     observedGeneration: 1

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Events.yaml
@@ -101,101 +101,6 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object ds (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Config ytserver-discovery.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object discovery (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
     resourceVersion: "3"
   lastTimestamp: null
   message: Config client.yson needs creation
@@ -332,6 +237,101 @@
     resourceVersion: "5"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object ds (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Config ytserver-discovery.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object discovery (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Ytsaurus.yaml
@@ -135,12 +135,6 @@ status:
     status: "True"
     type: OperatorVersion
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 1, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: DiscoveryReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -152,6 +146,12 @@ status:
     reason: Ready
     status: "True"
     type: MasterReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 1, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DiscoveryReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 1, running 0, need 0'
     observedGeneration: 1

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Events.yaml
@@ -101,101 +101,6 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object ds (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Config ytserver-discovery.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object discovery (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
     resourceVersion: "3"
   lastTimestamp: null
   message: Config client.yson needs creation
@@ -332,6 +237,101 @@
     resourceVersion: "5"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object ds (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Config ytserver-discovery.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object discovery (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Ytsaurus.yaml
@@ -136,12 +136,6 @@ status:
     status: "True"
     type: OperatorVersion
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 1, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: DiscoveryReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -153,6 +147,12 @@ status:
     reason: Ready
     status: "True"
     type: MasterReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 1, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DiscoveryReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 1, running 0, need 0'
     observedGeneration: 1

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Events.yaml
@@ -101,101 +101,6 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object ds (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Config ytserver-discovery.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object discovery (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
     resourceVersion: "3"
   lastTimestamp: null
   message: Config client.yson needs creation
@@ -332,6 +237,101 @@
     resourceVersion: "5"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object ds (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Config ytserver-discovery.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object discovery (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Ytsaurus.yaml
@@ -137,12 +137,6 @@ status:
     status: "True"
     type: OperatorVersion
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 1, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: DiscoveryReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -154,6 +148,12 @@ status:
     reason: Ready
     status: "True"
     type: MasterReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 1, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DiscoveryReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 1, running 0, need 0'
     observedGeneration: 1

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Events.yaml
@@ -101,101 +101,6 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object ds (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Config ytserver-discovery.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object discovery (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
     resourceVersion: "3"
   lastTimestamp: null
   message: Config client.yson needs creation
@@ -332,6 +237,101 @@
     resourceVersion: "5"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object ds (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Config ytserver-discovery.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object discovery (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Ytsaurus.yaml
@@ -134,12 +134,6 @@ status:
     status: "True"
     type: OperatorVersion
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 1, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: DiscoveryReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -151,6 +145,12 @@ status:
     reason: Ready
     status: "True"
     type: MasterReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 1, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DiscoveryReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 1, running 0, need 0'
     observedGeneration: 1

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/Events.yaml
@@ -101,101 +101,6 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object ds (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Config ytserver-discovery.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object discovery (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
     resourceVersion: "3"
   lastTimestamp: null
   message: Config client.yson needs creation
@@ -332,6 +237,101 @@
     resourceVersion: "5"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object ds (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Config ytserver-discovery.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object discovery (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/Ytsaurus.yaml
@@ -133,12 +133,6 @@ status:
     status: "True"
     type: OperatorVersion
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 1, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: DiscoveryReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -150,6 +144,12 @@ status:
     reason: Ready
     status: "True"
     type: MasterReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 1, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DiscoveryReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 1, running 0, need 0'
     observedGeneration: 1

--- a/test/r8r/canondata/Components reconciler With SPYT Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/Events.yaml
@@ -101,101 +101,6 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object ds (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Config ytserver-discovery.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object discovery (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
     resourceVersion: "3"
   lastTimestamp: null
   message: Config client.yson needs creation
@@ -332,6 +237,101 @@
     resourceVersion: "5"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object ds (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Config ytserver-discovery.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object discovery (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler With SPYT Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/Ytsaurus.yaml
@@ -86,12 +86,6 @@ status:
     status: "True"
     type: OperatorVersion
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 1, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: DiscoveryReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -103,6 +97,12 @@ status:
     reason: Ready
     status: "True"
     type: MasterReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 1, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DiscoveryReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 1, running 0, need 0'
     observedGeneration: 1

--- a/test/r8r/canondata/Components reconciler With all components Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Events.yaml
@@ -343,101 +343,6 @@
     namespace: ytsaurus-components
     resourceVersion: "3"
   lastTimestamp: null
-  message: Created YT object ds (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
-  message: Config ytserver-discovery.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
-  message: Created YT object discovery (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
   message: Created YT object robot-timbertruck-secret (*v1.Secret)
   metadata:
     namespace: ytsaurus-components
@@ -686,6 +591,101 @@
     resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "7"
+  lastTimestamp: null
+  message: Created YT object ds (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "7"
+  lastTimestamp: null
+  message: Config ytserver-discovery.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "7"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "7"
+  lastTimestamp: null
+  message: Created YT object discovery (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "7"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler With all components Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Events.yaml
@@ -438,101 +438,6 @@
     namespace: ytsaurus-components
     resourceVersion: "3"
   lastTimestamp: null
-  message: Created YT object msc (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
-  message: Config ytserver-master-cache.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
-  message: Created YT object yt-master-cache-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
-  message: Created YT object master-caches (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
-  message: Created YT object yt-master-cache-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "3"
-  lastTimestamp: null
   message: Created YT object robot-timbertruck-secret (*v1.Secret)
   metadata:
     namespace: ytsaurus-components
@@ -1256,6 +1161,101 @@
     resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object yt-yql-agent-secret (*v1.Secret)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "7"
+  lastTimestamp: null
+  message: Created YT object msc (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "7"
+  lastTimestamp: null
+  message: Config ytserver-master-cache.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "7"
+  lastTimestamp: null
+  message: Created YT object yt-master-cache-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "7"
+  lastTimestamp: null
+  message: Created YT object master-caches (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "7"
+  lastTimestamp: null
+  message: Created YT object yt-master-cache-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
@@ -425,12 +425,6 @@ status:
     status: "True"
     type: DiscoveryReady
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 1, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: MasterCacheReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -460,6 +454,12 @@ status:
     reason: Ready
     status: "True"
     type: ControllerAgentReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 1, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: MasterCacheReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 1, running 0, need 0'
     observedGeneration: 1

--- a/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
@@ -419,12 +419,6 @@ status:
     status: "True"
     type: Master-2Ready
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 1, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: DiscoveryReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -436,6 +430,12 @@ status:
     reason: Ready
     status: "True"
     type: MasterReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 1, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DiscoveryReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 3, running 0, need 0'
     observedGeneration: 1

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/Events.yaml
@@ -101,101 +101,6 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object ds (*v1.StatefulSet)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Config ytserver-discovery.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object discovery (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "2"
-  lastTimestamp: null
-  message: Created YT object yt-discovery-monitoring (*v1.Service)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
     resourceVersion: "3"
   lastTimestamp: null
   message: Config client.yson needs creation
@@ -332,6 +237,101 @@
     resourceVersion: "5"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object ds (*v1.StatefulSet)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Config ytserver-discovery.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object discovery (*v1.Service)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "5"
+  lastTimestamp: null
+  message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/Ytsaurus.yaml
@@ -130,12 +130,6 @@ status:
     status: "True"
     type: OperatorVersion
   - lastTransitionTime: null
-    message: 'Pods are ready: 0 of 1, running 0, need 0'
-    observedGeneration: 1
-    reason: Ready
-    status: "True"
-    type: DiscoveryReady
-  - lastTransitionTime: null
     message: Job yt-master-init-job-default completed in -1ns
     observedGeneration: 1
     reason: ClusterInitialization
@@ -147,6 +141,12 @@ status:
     reason: Ready
     status: "True"
     type: MasterReady
+  - lastTransitionTime: null
+    message: 'Pods are ready: 0 of 1, running 0, need 0'
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DiscoveryReady
   - lastTransitionTime: null
     message: 'Pods are ready: 0 of 1, running 0, need 0'
     observedGeneration: 1


### PR DESCRIPTION
- **Start master caches only when masters are running**
- **Start discovery service only when masters are running**
- **Start tablet nodes only when masters are running**

Start master caches only when masters are running
Otherwise master caches and nodes could see and cache non-final cluster metadata.