### PR TITLE
Disable e2e tests for multicell master initialization

### DIFF
--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -883,6 +883,10 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 						Skip("YTsaurus old/new version does not support multicell")
 					}
 
+					if os.Getenv("YTSAURUS_MULTICELL_READY") == "" {
+						Skip("Multicell cluster initialization is broken")
+					}
+
 					By("Setting 3 master replicas")
 					ytsaurus.Spec.PrimaryMasters.InstanceCount = 3
 
@@ -2190,6 +2194,10 @@ exec "$@"`
 			Context("Create cluster with secondary master", Label("initialization"), func() {
 
 				BeforeEach(func() {
+					if os.Getenv("YTSAURUS_MULTICELL_READY") == "" {
+						Skip("Multicell cluster initialization is broken")
+					}
+
 					By("Setting 3 replicas for each master cell")
 					ytsaurus.Spec.PrimaryMasters.InstanceCount = 3
 


### PR DESCRIPTION
There are too many bugs for now for testing this scenario frequently.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
