### PR TITLE
Fix init job (re)start consistency

### DIFF
--- a/pkg/components/init_job.go
+++ b/pkg/components/init_job.go
@@ -300,7 +300,7 @@ func (j *InitJob) Exists() bool {
 	return resources.Exists(j.initJob, j.configs)
 }
 
-func (j *InitJob) start(ctx context.Context, dry bool, isRestarted bool) (ComponentStatus, error) {
+func (j *InitJob) start(ctx context.Context, dry, isStarted, isRestarted bool) (ComponentStatus, error) {
 	if dry {
 		return ComponentStatusWaitingFor("job %s start", j.Name()), nil
 	}
@@ -311,12 +311,28 @@ func (j *InitJob) start(ctx context.Context, dry bool, isRestarted bool) (Compon
 		return ComponentStatusWaitingFor("job %v delete", j.Name()), err
 	}
 
+	if isRestarted && j.configs.Exists() {
+		err := j.configs.configMap.DeleteBackground(ctx)
+		return ComponentStatusWaitingFor("job %v configmap %v delete", j.Name(), j.configs.GetConfigMapName()), err
+	}
+
+	if !isStarted {
+		// NOTE: Set condition reason to checkpoint fresh (re)start.
+		j.owner.SetStatusCondition(metav1.Condition{
+			Type:    j.statusCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  j.reason,
+			Message: fmt.Sprintf("Job %s starting", j.Name()),
+		})
+		return ComponentStatusWaitingFor("job %v starting for reason %v", j.Name(), j.reason), nil
+	}
+
 	if _, err := j.configs.Build(); err != nil {
 		return ComponentStatusWaitingFor("job %v configmap %v", j.Name(), j.configs.GetConfigMapName()), err
 	}
 
 	// NOTE: Track job reason in configmap annotation but not recreate to allow manual fixes for failing job.
-	if isRestarted || !j.configs.Exists() || j.configs.getAnnotation(consts.InitJobReasonAnnotationName) != j.reason {
+	if !j.configs.Exists() || j.configs.getAnnotation(consts.InitJobReasonAnnotationName) != j.reason {
 		j.configs.setAnnotation(consts.InitJobReasonAnnotationName, j.reason)
 		if err := j.configs.Sync(ctx); err != nil {
 			return ComponentStatusWaitingFor("job %v configmap %v", j.Name(), j.configs.GetConfigMapName()), err
@@ -347,9 +363,9 @@ func (j *InitJob) Sync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	}
 
 	isStarted := condition != nil && condition.Reason == j.reason
-	if !isExists || !isStarted || j.initJob.IsFailed() {
+	if !isStarted || !isExists || j.initJob.IsFailed() {
 		isRestarted := condition == nil
-		return j.start(ctx, dry, isRestarted)
+		return j.start(ctx, dry, isStarted, isRestarted)
 	}
 
 	if !j.initJob.IsComplete() {

--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -79,6 +79,10 @@ func (r *BaseManagedResource[T]) Sync(ctx context.Context) error {
 	return r.proxy.SyncObject(ctx, r.oldObject, r.newObject)
 }
 
+func (r *BaseManagedResource[T]) DeleteBackground(ctx context.Context) error {
+	return r.proxy.DeleteObject(ctx, r.oldObject, client.PropagationPolicy(metav1.DeletePropagationBackground))
+}
+
 func (r *BaseManagedResource[T]) DeleteForeground(ctx context.Context) error {
 	return r.proxy.DeleteObject(ctx, r.oldObject, client.PropagationPolicy(metav1.DeletePropagationForeground))
 }

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/Events.yaml
@@ -235,7 +235,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "4"
+    resourceVersion: "5"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -254,7 +254,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "4"
+    resourceVersion: "5"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default-config (*v1.ConfigMap)
   metadata:
@@ -273,7 +273,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "4"
+    resourceVersion: "5"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default (*v1.Job)
   metadata:
@@ -292,7 +292,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object hp (*v1.StatefulSet)
   metadata:
@@ -311,7 +311,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Config ytserver-http-proxy.yson needs creation
   metadata:
@@ -330,7 +330,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-config (*v1.ConfigMap)
   metadata:
@@ -349,7 +349,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object http-proxies (*v1.Service)
   metadata:
@@ -368,7 +368,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
   metadata:
@@ -387,7 +387,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object ds (*v1.StatefulSet)
   metadata:
@@ -406,7 +406,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Config ytserver-discovery.yson needs creation
   metadata:
@@ -425,7 +425,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object yt-discovery-config (*v1.ConfigMap)
   metadata:
@@ -444,7 +444,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object discovery (*v1.Service)
   metadata:
@@ -463,7 +463,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
@@ -482,7 +482,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object http-proxies-lb (*v1.Service)
   metadata:
@@ -501,7 +501,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "11"
   lastTimestamp: null
   message: Created YT object yt-client-secret (*v1.Secret)
   metadata:
@@ -520,7 +520,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "11"
+    resourceVersion: "13"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -539,7 +539,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "11"
+    resourceVersion: "13"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -558,7 +558,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "11"
+    resourceVersion: "13"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user (*v1.Job)
   metadata:
@@ -577,7 +577,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "13"
+    resourceVersion: "15"
   lastTimestamp: null
   message: Created YT object yt-cypress-patch (*v1.ConfigMap)
   metadata:
@@ -596,7 +596,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "13"
+    resourceVersion: "15"
   lastTimestamp: null
   message: Skip patch apply in test
   metadata:

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/Ytsaurus.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "16"
+  resourceVersion: "18"
 spec:
   clusterFeatures: {}
   coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.2

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/Events.yaml
@@ -386,7 +386,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -405,7 +405,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default-config (*v1.ConfigMap)
   metadata:
@@ -424,7 +424,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default (*v1.Job)
   metadata:
@@ -443,7 +443,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object hp (*v1.StatefulSet)
   metadata:
@@ -462,7 +462,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-http-proxy.yson needs creation
   metadata:
@@ -481,7 +481,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-config (*v1.ConfigMap)
   metadata:
@@ -500,7 +500,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object http-proxies (*v1.Service)
   metadata:
@@ -519,7 +519,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
   metadata:
@@ -538,7 +538,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object ds (*v1.StatefulSet)
   metadata:
@@ -557,7 +557,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-discovery.yson needs creation
   metadata:
@@ -576,7 +576,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-config (*v1.ConfigMap)
   metadata:
@@ -595,7 +595,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object discovery (*v1.Service)
   metadata:
@@ -614,7 +614,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
@@ -633,7 +633,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object http-proxies-lb (*v1.Service)
   metadata:
@@ -652,7 +652,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Created YT object yt-client-secret (*v1.Secret)
   metadata:
@@ -671,7 +671,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -690,7 +690,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -709,7 +709,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user (*v1.Job)
   metadata:
@@ -728,7 +728,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Created YT object yt-cypress-patch (*v1.ConfigMap)
   metadata:
@@ -747,7 +747,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Skip patch apply in test
   metadata:

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/Ytsaurus.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "15"
+  resourceVersion: "17"
 spec:
   clusterFeatures: {}
   coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.2

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/Events.yaml
@@ -196,7 +196,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -215,7 +215,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default-config (*v1.ConfigMap)
   metadata:
@@ -234,7 +234,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default (*v1.Job)
   metadata:
@@ -253,7 +253,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object hp (*v1.StatefulSet)
   metadata:
@@ -272,7 +272,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-http-proxy.yson needs creation
   metadata:
@@ -291,7 +291,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-config (*v1.ConfigMap)
   metadata:
@@ -310,7 +310,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object http-proxies (*v1.Service)
   metadata:
@@ -329,7 +329,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
   metadata:
@@ -348,7 +348,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object ds (*v1.StatefulSet)
   metadata:
@@ -367,7 +367,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-discovery.yson needs creation
   metadata:
@@ -386,7 +386,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-config (*v1.ConfigMap)
   metadata:
@@ -405,7 +405,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object discovery (*v1.Service)
   metadata:
@@ -424,7 +424,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
@@ -443,7 +443,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object http-proxies-lb (*v1.Service)
   metadata:
@@ -462,7 +462,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Created YT object yt-client-secret (*v1.Secret)
   metadata:
@@ -481,7 +481,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -500,7 +500,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -519,7 +519,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user (*v1.Job)
   metadata:
@@ -538,7 +538,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Created YT object yt-cypress-patch (*v1.ConfigMap)
   metadata:
@@ -557,7 +557,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Skip patch apply in test
   metadata:
@@ -576,7 +576,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "14"
+    resourceVersion: "16"
   lastTimestamp: null
   message: Ytsaurus cluster is under maintenance, shutdown ExceptMasters
   metadata:

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/Ytsaurus.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "15"
+  resourceVersion: "17"
 spec:
   clusterFeatures: {}
   clusterMaintenance:

--- a/test/r8r/canondata/Components reconciler Minimal Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/Events.yaml
@@ -101,7 +101,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -120,7 +120,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default-config (*v1.ConfigMap)
   metadata:
@@ -139,7 +139,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default (*v1.Job)
   metadata:
@@ -158,7 +158,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object hp (*v1.StatefulSet)
   metadata:
@@ -177,7 +177,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-http-proxy.yson needs creation
   metadata:
@@ -196,7 +196,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-config (*v1.ConfigMap)
   metadata:
@@ -215,7 +215,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object http-proxies (*v1.Service)
   metadata:
@@ -234,7 +234,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
   metadata:
@@ -253,7 +253,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object ds (*v1.StatefulSet)
   metadata:
@@ -272,7 +272,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-discovery.yson needs creation
   metadata:
@@ -291,7 +291,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-config (*v1.ConfigMap)
   metadata:
@@ -310,7 +310,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object discovery (*v1.Service)
   metadata:
@@ -329,7 +329,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
@@ -348,7 +348,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object http-proxies-lb (*v1.Service)
   metadata:
@@ -367,7 +367,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Created YT object yt-client-secret (*v1.Secret)
   metadata:
@@ -386,7 +386,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -405,7 +405,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -424,7 +424,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user (*v1.Job)
   metadata:
@@ -443,7 +443,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Created YT object yt-cypress-patch (*v1.ConfigMap)
   metadata:
@@ -462,7 +462,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Skip patch apply in test
   metadata:

--- a/test/r8r/canondata/Components reconciler Minimal Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/Ytsaurus.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "15"
+  resourceVersion: "17"
 spec:
   clusterFeatures: {}
   coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.2

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Chyt.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Chyt.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "7"
+  resourceVersion: "9"
 spec:
   createPublicClique: true
   image: ghcr.io/ytsaurus/chyt:2.18.3

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Events.yaml
@@ -101,7 +101,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -120,7 +120,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default-config (*v1.ConfigMap)
   metadata:
@@ -139,7 +139,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default (*v1.Job)
   metadata:
@@ -158,7 +158,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object hp (*v1.StatefulSet)
   metadata:
@@ -177,7 +177,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-http-proxy.yson needs creation
   metadata:
@@ -196,7 +196,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-config (*v1.ConfigMap)
   metadata:
@@ -215,7 +215,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object http-proxies (*v1.Service)
   metadata:
@@ -234,7 +234,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
   metadata:
@@ -253,7 +253,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object ds (*v1.StatefulSet)
   metadata:
@@ -272,7 +272,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-discovery.yson needs creation
   metadata:
@@ -291,7 +291,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-config (*v1.ConfigMap)
   metadata:
@@ -310,7 +310,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object discovery (*v1.Service)
   metadata:
@@ -329,7 +329,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
@@ -348,7 +348,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object http-proxies-lb (*v1.Service)
   metadata:
@@ -367,7 +367,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Created YT object yt-client-secret (*v1.Secret)
   metadata:
@@ -386,7 +386,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -405,7 +405,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -424,7 +424,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user (*v1.Job)
   metadata:
@@ -443,7 +443,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Created YT object yt-cypress-patch (*v1.ConfigMap)
   metadata:
@@ -462,7 +462,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Skip patch apply in test
   metadata:
@@ -500,7 +500,7 @@
     kind: Chyt
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
+    resourceVersion: "3"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -519,7 +519,7 @@
     kind: Chyt
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
+    resourceVersion: "3"
   lastTimestamp: null
   message: Created YT object yt-chyt-test-ytsaurus-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -538,7 +538,7 @@
     kind: Chyt
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
+    resourceVersion: "3"
   lastTimestamp: null
   message: Created YT object yt-chyt-test-ytsaurus-init-job-user (*v1.Job)
   metadata:
@@ -557,7 +557,7 @@
     kind: Chyt
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "4"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -576,7 +576,7 @@
     kind: Chyt
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "4"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-chyt-test-ytsaurus-init-job-release-config (*v1.ConfigMap)
   metadata:
@@ -595,7 +595,7 @@
     kind: Chyt
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "4"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-chyt-test-ytsaurus-init-job-release (*v1.Job)
   metadata:

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Ytsaurus.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "15"
+  resourceVersion: "17"
 spec:
   clusterFeatures: {}
   coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.2

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Events.yaml
@@ -101,7 +101,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -120,7 +120,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default-config (*v1.ConfigMap)
   metadata:
@@ -139,7 +139,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default (*v1.Job)
   metadata:
@@ -158,7 +158,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object hp (*v1.StatefulSet)
   metadata:
@@ -177,7 +177,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-http-proxy.yson needs creation
   metadata:
@@ -196,7 +196,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-config (*v1.ConfigMap)
   metadata:
@@ -215,7 +215,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object http-proxies (*v1.Service)
   metadata:
@@ -234,7 +234,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
   metadata:
@@ -253,7 +253,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object ds (*v1.StatefulSet)
   metadata:
@@ -272,7 +272,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-discovery.yson needs creation
   metadata:
@@ -291,7 +291,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-config (*v1.ConfigMap)
   metadata:
@@ -310,7 +310,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object discovery (*v1.Service)
   metadata:
@@ -329,7 +329,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
@@ -348,7 +348,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object end (*v1.StatefulSet)
   metadata:
@@ -367,7 +367,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-exec-node.yson needs creation
   metadata:
@@ -386,7 +386,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-config (*v1.ConfigMap)
   metadata:
@@ -405,7 +405,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object exec-nodes (*v1.Service)
   metadata:
@@ -424,7 +424,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-monitoring (*v1.Service)
   metadata:
@@ -443,7 +443,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config containerd.toml needs creation
   metadata:
@@ -462,7 +462,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-jobs-config (*v1.ConfigMap)
   metadata:
@@ -481,7 +481,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object http-proxies-lb (*v1.Service)
   metadata:
@@ -500,7 +500,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Created YT object yt-client-secret (*v1.Secret)
   metadata:
@@ -519,7 +519,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -538,7 +538,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -557,7 +557,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user (*v1.Job)
   metadata:
@@ -576,7 +576,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Created YT object yt-cypress-patch (*v1.ConfigMap)
   metadata:
@@ -595,7 +595,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Skip patch apply in test
   metadata:

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Ytsaurus.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "15"
+  resourceVersion: "17"
 spec:
   clusterFeatures: {}
   configOverrides:

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Events.yaml
@@ -101,7 +101,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -120,7 +120,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default-config (*v1.ConfigMap)
   metadata:
@@ -139,7 +139,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default (*v1.Job)
   metadata:
@@ -158,7 +158,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object hp (*v1.StatefulSet)
   metadata:
@@ -177,7 +177,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-http-proxy.yson needs creation
   metadata:
@@ -196,7 +196,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-config (*v1.ConfigMap)
   metadata:
@@ -215,7 +215,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object http-proxies (*v1.Service)
   metadata:
@@ -234,7 +234,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
   metadata:
@@ -253,7 +253,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object ds (*v1.StatefulSet)
   metadata:
@@ -272,7 +272,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-discovery.yson needs creation
   metadata:
@@ -291,7 +291,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-config (*v1.ConfigMap)
   metadata:
@@ -310,7 +310,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object discovery (*v1.Service)
   metadata:
@@ -329,7 +329,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
@@ -348,7 +348,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object end (*v1.StatefulSet)
   metadata:
@@ -367,7 +367,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-exec-node.yson needs creation
   metadata:
@@ -386,7 +386,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-config (*v1.ConfigMap)
   metadata:
@@ -405,7 +405,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object exec-nodes (*v1.Service)
   metadata:
@@ -424,7 +424,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-monitoring (*v1.Service)
   metadata:
@@ -443,7 +443,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config crio.conf needs creation
   metadata:
@@ -462,7 +462,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-jobs-config (*v1.ConfigMap)
   metadata:
@@ -481,7 +481,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object http-proxies-lb (*v1.Service)
   metadata:
@@ -500,7 +500,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Created YT object yt-client-secret (*v1.Secret)
   metadata:
@@ -519,7 +519,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -538,7 +538,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -557,7 +557,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user (*v1.Job)
   metadata:
@@ -576,7 +576,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Created YT object yt-cypress-patch (*v1.ConfigMap)
   metadata:
@@ -595,7 +595,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Skip patch apply in test
   metadata:

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Ytsaurus.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "15"
+  resourceVersion: "17"
 spec:
   clusterFeatures: {}
   coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.2

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Events.yaml
@@ -101,7 +101,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -120,7 +120,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default-config (*v1.ConfigMap)
   metadata:
@@ -139,7 +139,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default (*v1.Job)
   metadata:
@@ -158,7 +158,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object hp (*v1.StatefulSet)
   metadata:
@@ -177,7 +177,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-http-proxy.yson needs creation
   metadata:
@@ -196,7 +196,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-config (*v1.ConfigMap)
   metadata:
@@ -215,7 +215,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object http-proxies (*v1.Service)
   metadata:
@@ -234,7 +234,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
   metadata:
@@ -253,7 +253,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object ds (*v1.StatefulSet)
   metadata:
@@ -272,7 +272,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-discovery.yson needs creation
   metadata:
@@ -291,7 +291,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-config (*v1.ConfigMap)
   metadata:
@@ -310,7 +310,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object discovery (*v1.Service)
   metadata:
@@ -329,7 +329,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
@@ -348,7 +348,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object end (*v1.StatefulSet)
   metadata:
@@ -367,7 +367,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-exec-node.yson needs creation
   metadata:
@@ -386,7 +386,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-config (*v1.ConfigMap)
   metadata:
@@ -405,7 +405,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object exec-nodes (*v1.Service)
   metadata:
@@ -424,7 +424,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-monitoring (*v1.Service)
   metadata:
@@ -443,7 +443,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config containerd.toml needs creation
   metadata:
@@ -462,7 +462,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-jobs-config (*v1.ConfigMap)
   metadata:
@@ -481,7 +481,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object http-proxies-lb (*v1.Service)
   metadata:
@@ -500,7 +500,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Created YT object yt-client-secret (*v1.Secret)
   metadata:
@@ -519,7 +519,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -538,7 +538,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -557,7 +557,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user (*v1.Job)
   metadata:
@@ -576,7 +576,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Created YT object yt-cypress-patch (*v1.ConfigMap)
   metadata:
@@ -595,7 +595,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Skip patch apply in test
   metadata:

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Ytsaurus.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "15"
+  resourceVersion: "17"
 spec:
   clusterFeatures: {}
   configOverrides:

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Events.yaml
@@ -101,7 +101,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -120,7 +120,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default-config (*v1.ConfigMap)
   metadata:
@@ -139,7 +139,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default (*v1.Job)
   metadata:
@@ -158,7 +158,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object hp (*v1.StatefulSet)
   metadata:
@@ -177,7 +177,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-http-proxy.yson needs creation
   metadata:
@@ -196,7 +196,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-config (*v1.ConfigMap)
   metadata:
@@ -215,7 +215,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object http-proxies (*v1.Service)
   metadata:
@@ -234,7 +234,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
   metadata:
@@ -253,7 +253,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object ds (*v1.StatefulSet)
   metadata:
@@ -272,7 +272,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-discovery.yson needs creation
   metadata:
@@ -291,7 +291,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-config (*v1.ConfigMap)
   metadata:
@@ -310,7 +310,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object discovery (*v1.Service)
   metadata:
@@ -329,7 +329,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
@@ -348,7 +348,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object end (*v1.StatefulSet)
   metadata:
@@ -367,7 +367,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-exec-node.yson needs creation
   metadata:
@@ -386,7 +386,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-config (*v1.ConfigMap)
   metadata:
@@ -405,7 +405,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object exec-nodes (*v1.Service)
   metadata:
@@ -424,7 +424,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-monitoring (*v1.Service)
   metadata:
@@ -443,7 +443,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config crio.conf needs creation
   metadata:
@@ -462,7 +462,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-jobs-config (*v1.ConfigMap)
   metadata:
@@ -481,7 +481,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object http-proxies-lb (*v1.Service)
   metadata:
@@ -500,7 +500,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Created YT object yt-client-secret (*v1.Secret)
   metadata:
@@ -519,7 +519,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -538,7 +538,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -557,7 +557,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user (*v1.Job)
   metadata:
@@ -576,7 +576,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Created YT object yt-cypress-patch (*v1.ConfigMap)
   metadata:
@@ -595,7 +595,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Skip patch apply in test
   metadata:

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Ytsaurus.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "15"
+  resourceVersion: "17"
 spec:
   clusterFeatures: {}
   coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.2

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/Events.yaml
@@ -101,7 +101,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -120,7 +120,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default-config (*v1.ConfigMap)
   metadata:
@@ -139,7 +139,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default (*v1.Job)
   metadata:
@@ -158,7 +158,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object hp (*v1.StatefulSet)
   metadata:
@@ -177,7 +177,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-http-proxy.yson needs creation
   metadata:
@@ -196,7 +196,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-config (*v1.ConfigMap)
   metadata:
@@ -215,7 +215,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object http-proxies (*v1.Service)
   metadata:
@@ -234,7 +234,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
   metadata:
@@ -253,7 +253,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object ds (*v1.StatefulSet)
   metadata:
@@ -272,7 +272,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-discovery.yson needs creation
   metadata:
@@ -291,7 +291,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-config (*v1.ConfigMap)
   metadata:
@@ -310,7 +310,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object discovery (*v1.Service)
   metadata:
@@ -329,7 +329,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
@@ -348,7 +348,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object end (*v1.StatefulSet)
   metadata:
@@ -367,7 +367,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-exec-node.yson needs creation
   metadata:
@@ -386,7 +386,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-config (*v1.ConfigMap)
   metadata:
@@ -405,7 +405,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object exec-nodes (*v1.Service)
   metadata:
@@ -424,7 +424,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-monitoring (*v1.Service)
   metadata:
@@ -443,7 +443,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config containerd.toml needs creation
   metadata:
@@ -462,7 +462,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-jobs-config (*v1.ConfigMap)
   metadata:
@@ -481,7 +481,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object http-proxies-lb (*v1.Service)
   metadata:
@@ -500,7 +500,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Created YT object yt-client-secret (*v1.Secret)
   metadata:
@@ -519,7 +519,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -538,7 +538,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -557,7 +557,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user (*v1.Job)
   metadata:
@@ -576,7 +576,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Created YT object yt-cypress-patch (*v1.ConfigMap)
   metadata:
@@ -595,7 +595,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Skip patch apply in test
   metadata:

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/Ytsaurus.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "15"
+  resourceVersion: "17"
 spec:
   clusterFeatures: {}
   configOverrides:

--- a/test/r8r/canondata/Components reconciler With SPYT Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/Events.yaml
@@ -101,7 +101,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -120,7 +120,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default-config (*v1.ConfigMap)
   metadata:
@@ -139,7 +139,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default (*v1.Job)
   metadata:
@@ -158,7 +158,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object hp (*v1.StatefulSet)
   metadata:
@@ -177,7 +177,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-http-proxy.yson needs creation
   metadata:
@@ -196,7 +196,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-config (*v1.ConfigMap)
   metadata:
@@ -215,7 +215,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object http-proxies (*v1.Service)
   metadata:
@@ -234,7 +234,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
   metadata:
@@ -253,7 +253,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object ds (*v1.StatefulSet)
   metadata:
@@ -272,7 +272,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-discovery.yson needs creation
   metadata:
@@ -291,7 +291,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-config (*v1.ConfigMap)
   metadata:
@@ -310,7 +310,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object discovery (*v1.Service)
   metadata:
@@ -329,7 +329,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
@@ -348,7 +348,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object http-proxies-lb (*v1.Service)
   metadata:
@@ -367,7 +367,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Created YT object yt-client-secret (*v1.Secret)
   metadata:
@@ -386,7 +386,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -405,7 +405,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -424,7 +424,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user (*v1.Job)
   metadata:
@@ -443,7 +443,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Created YT object yt-cypress-patch (*v1.ConfigMap)
   metadata:
@@ -462,7 +462,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Skip patch apply in test
   metadata:
@@ -500,7 +500,7 @@
     kind: Spyt
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
+    resourceVersion: "3"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -519,7 +519,7 @@
     kind: Spyt
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
+    resourceVersion: "3"
   lastTimestamp: null
   message: Created YT object yt-spyt-test-ytsaurus-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -538,7 +538,7 @@
     kind: Spyt
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "2"
+    resourceVersion: "3"
   lastTimestamp: null
   message: Created YT object yt-spyt-test-ytsaurus-init-job-user (*v1.Job)
   metadata:
@@ -557,7 +557,7 @@
     kind: Spyt
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "4"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -576,7 +576,7 @@
     kind: Spyt
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "4"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-spyt-test-ytsaurus-init-job-spyt-environment-config
     (*v1.ConfigMap)
@@ -596,7 +596,7 @@
     kind: Spyt
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "4"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-spyt-test-ytsaurus-init-job-spyt-environment (*v1.Job)
   metadata:

--- a/test/r8r/canondata/Components reconciler With SPYT Test/Spyt.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/Spyt.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "7"
+  resourceVersion: "9"
 spec:
   ytsaurus:
     name: test-ytsaurus

--- a/test/r8r/canondata/Components reconciler With SPYT Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/Ytsaurus.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "15"
+  resourceVersion: "17"
 spec:
   clusterFeatures: {}
   coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.2

--- a/test/r8r/canondata/Components reconciler With all components Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Events.yaml
@@ -455,7 +455,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -474,7 +474,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default-config (*v1.ConfigMap)
   metadata:
@@ -493,7 +493,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default (*v1.Job)
   metadata:
@@ -512,7 +512,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object hp (*v1.StatefulSet)
   metadata:
@@ -531,7 +531,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Config ytserver-http-proxy.yson needs creation
   metadata:
@@ -550,7 +550,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-config (*v1.ConfigMap)
   metadata:
@@ -569,7 +569,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object http-proxies (*v1.Service)
   metadata:
@@ -588,7 +588,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
   metadata:
@@ -607,7 +607,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object ds (*v1.StatefulSet)
   metadata:
@@ -626,7 +626,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Config ytserver-discovery.yson needs creation
   metadata:
@@ -645,7 +645,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-discovery-config (*v1.ConfigMap)
   metadata:
@@ -664,7 +664,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object discovery (*v1.Service)
   metadata:
@@ -683,7 +683,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
@@ -702,7 +702,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object dnd (*v1.StatefulSet)
   metadata:
@@ -721,7 +721,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Config ytserver-data-node.yson needs creation
   metadata:
@@ -740,7 +740,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-data-node-config (*v1.ConfigMap)
   metadata:
@@ -759,7 +759,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object data-nodes (*v1.Service)
   metadata:
@@ -778,7 +778,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-data-node-monitoring (*v1.Service)
   metadata:
@@ -797,7 +797,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-ui-secret (*v1.Secret)
   metadata:
@@ -816,7 +816,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object rp (*v1.StatefulSet)
   metadata:
@@ -835,7 +835,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Config ytserver-rpc-proxy.yson needs creation
   metadata:
@@ -854,7 +854,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-rpc-proxy-config (*v1.ConfigMap)
   metadata:
@@ -873,7 +873,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object rpc-proxies (*v1.Service)
   metadata:
@@ -892,7 +892,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-rpc-proxy-monitoring (*v1.Service)
   metadata:
@@ -911,7 +911,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object end (*v1.StatefulSet)
   metadata:
@@ -930,7 +930,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Config ytserver-exec-node.yson needs creation
   metadata:
@@ -949,7 +949,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-exec-node-config (*v1.ConfigMap)
   metadata:
@@ -968,7 +968,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object exec-nodes (*v1.Service)
   metadata:
@@ -987,7 +987,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-exec-node-monitoring (*v1.Service)
   metadata:
@@ -1006,7 +1006,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Config containerd.toml needs creation
   metadata:
@@ -1025,7 +1025,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-exec-node-jobs-config (*v1.ConfigMap)
   metadata:
@@ -1044,7 +1044,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-scheduler-secret (*v1.Secret)
   metadata:
@@ -1063,7 +1063,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object ca (*v1.StatefulSet)
   metadata:
@@ -1082,7 +1082,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Config ytserver-controller-agent.yson needs creation
   metadata:
@@ -1101,7 +1101,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-controller-agent-config (*v1.ConfigMap)
   metadata:
@@ -1120,7 +1120,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object controller-agents (*v1.Service)
   metadata:
@@ -1139,7 +1139,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-controller-agent-monitoring (*v1.Service)
   metadata:
@@ -1158,7 +1158,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-yql-agent-secret (*v1.Secret)
   metadata:
@@ -1177,7 +1177,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object msc (*v1.StatefulSet)
   metadata:
@@ -1196,7 +1196,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Config ytserver-master-cache.yson needs creation
   metadata:
@@ -1215,7 +1215,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-master-cache-config (*v1.ConfigMap)
   metadata:
@@ -1234,7 +1234,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object master-caches (*v1.Service)
   metadata:
@@ -1253,7 +1253,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "7"
+    resourceVersion: "8"
   lastTimestamp: null
   message: Created YT object yt-master-cache-monitoring (*v1.Service)
   metadata:
@@ -1272,7 +1272,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "8"
+    resourceVersion: "9"
   lastTimestamp: null
   message: Created YT object http-proxies-lb (*v1.Service)
   metadata:
@@ -1291,64 +1291,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "8"
-  lastTimestamp: null
-  message: Config client.yson needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "8"
-  lastTimestamp: null
-  message: Created YT object yt-ui-init-job-default-config (*v1.ConfigMap)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "8"
-  lastTimestamp: null
-  message: Created YT object yt-ui-init-job-default (*v1.Job)
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "8"
+    resourceVersion: "9"
   lastTimestamp: null
   message: Created YT object rpc-proxies-lb (*v1.Service)
   metadata:
@@ -1367,7 +1310,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "8"
+    resourceVersion: "9"
   lastTimestamp: null
   message: Created YT object sch (*v1.StatefulSet)
   metadata:
@@ -1386,7 +1329,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "8"
+    resourceVersion: "9"
   lastTimestamp: null
   message: Config ytserver-scheduler.yson needs creation
   metadata:
@@ -1405,7 +1348,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "8"
+    resourceVersion: "9"
   lastTimestamp: null
   message: Created YT object yt-scheduler-config (*v1.ConfigMap)
   metadata:
@@ -1424,7 +1367,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "8"
+    resourceVersion: "9"
   lastTimestamp: null
   message: Created YT object schedulers (*v1.Service)
   metadata:
@@ -1443,7 +1386,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "8"
+    resourceVersion: "9"
   lastTimestamp: null
   message: Created YT object yt-scheduler-monitoring (*v1.Service)
   metadata:
@@ -1462,7 +1405,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "8"
+    resourceVersion: "9"
   lastTimestamp: null
   message: Created YT object yt-yql-agent-exec-secret (*v1.Secret)
   metadata:
@@ -1481,7 +1424,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Created YT object yt-client-secret (*v1.Secret)
   metadata:
@@ -1500,7 +1443,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -1519,9 +1462,9 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
-  message: Created YT object yt-yql-agent-init-job-yql-agent-environment-config (*v1.ConfigMap)
+  message: Created YT object yt-ui-init-job-default-config (*v1.ConfigMap)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation
@@ -1538,9 +1481,9 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
-  message: Created YT object yt-yql-agent-init-job-yql-agent-environment (*v1.Job)
+  message: Created YT object yt-ui-init-job-default (*v1.Job)
   metadata:
     namespace: ytsaurus-components
   reason: Reconciliation
@@ -1557,7 +1500,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Created YT object yt-strawberry-controller-secret (*v1.Secret)
   metadata:
@@ -1576,26 +1519,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
-  lastTimestamp: null
-  message: Config clusters-config.json needs creation
-  metadata:
-    namespace: ytsaurus-components
-  reason: Reconciliation
-  reportingComponent: ytsaurus
-  reportingInstance: ""
-  source:
-    component: ytsaurus
-  type: Normal
-- count: 1
-  eventTime: null
-  firstTimestamp: null
-  involvedObject:
-    apiVersion: cluster.ytsaurus.tech/v1
-    kind: Ytsaurus
-    name: test-ytsaurus
-    namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "11"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -1614,7 +1538,83 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "11"
+  lastTimestamp: null
+  message: Created YT object yt-yql-agent-init-job-yql-agent-environment-config (*v1.ConfigMap)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "11"
+  lastTimestamp: null
+  message: Created YT object yt-yql-agent-init-job-yql-agent-environment (*v1.Job)
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "12"
+  lastTimestamp: null
+  message: Config clusters-config.json needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "12"
+  lastTimestamp: null
+  message: Config client.yson needs creation
+  metadata:
+    namespace: ytsaurus-components
+  reason: Reconciliation
+  reportingComponent: ytsaurus
+  reportingInstance: ""
+  source:
+    component: ytsaurus
+  type: Normal
+- count: 1
+  eventTime: null
+  firstTimestamp: null
+  involvedObject:
+    apiVersion: cluster.ytsaurus.tech/v1
+    kind: Ytsaurus
+    name: test-ytsaurus
+    namespace: ytsaurus-components
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -1633,7 +1633,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user (*v1.Job)
   metadata:
@@ -1652,7 +1652,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config clusters-config.json needs creation
   metadata:
@@ -1671,7 +1671,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config clusters-config.json needs creation
   metadata:
@@ -1690,7 +1690,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object ytsaurus-ui-deployment (*v1.Deployment)
   metadata:
@@ -1709,7 +1709,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config clusters-config.json needs creation
   metadata:
@@ -1728,7 +1728,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-ui-config (*v1.ConfigMap)
   metadata:
@@ -1747,7 +1747,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object ytsaurus-ui (*v1.Service)
   metadata:
@@ -1766,7 +1766,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -1785,7 +1785,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-strawberry-controller-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -1804,7 +1804,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-strawberry-controller-init-job-user (*v1.Job)
   metadata:
@@ -1823,7 +1823,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "11"
+    resourceVersion: "13"
   lastTimestamp: null
   message: Created YT object yqla (*v1.StatefulSet)
   metadata:
@@ -1842,7 +1842,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "11"
+    resourceVersion: "13"
   lastTimestamp: null
   message: Config ytserver-yql-agent.yson needs creation
   metadata:
@@ -1861,7 +1861,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "11"
+    resourceVersion: "13"
   lastTimestamp: null
   message: Created YT object yt-yql-agent-config (*v1.ConfigMap)
   metadata:
@@ -1880,7 +1880,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "11"
+    resourceVersion: "13"
   lastTimestamp: null
   message: Created YT object yql-agents (*v1.Service)
   metadata:
@@ -1899,7 +1899,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "11"
+    resourceVersion: "13"
   lastTimestamp: null
   message: Created YT object yt-yql-agent-monitoring (*v1.Service)
   metadata:
@@ -1918,7 +1918,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Created YT object yt-cypress-patch (*v1.ConfigMap)
   metadata:
@@ -1937,7 +1937,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Skip patch apply in test
   metadata:
@@ -1956,7 +1956,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "13"
+    resourceVersion: "16"
   lastTimestamp: null
   message: Config chyt-init-cluster.yson needs creation
   metadata:
@@ -1975,7 +1975,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "13"
+    resourceVersion: "16"
   lastTimestamp: null
   message: Created YT object yt-strawberry-controller-init-job-cluster-config (*v1.ConfigMap)
   metadata:
@@ -1994,7 +1994,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "13"
+    resourceVersion: "16"
   lastTimestamp: null
   message: Created YT object yt-strawberry-controller-init-job-cluster (*v1.Job)
   metadata:
@@ -2013,7 +2013,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "15"
+    resourceVersion: "18"
   lastTimestamp: null
   message: Config strawberry-controller.yson needs creation
   metadata:
@@ -2032,7 +2032,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "15"
+    resourceVersion: "18"
   lastTimestamp: null
   message: Config strawberry-controller.yson needs creation
   metadata:
@@ -2051,7 +2051,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "15"
+    resourceVersion: "18"
   lastTimestamp: null
   message: Config strawberry-controller.yson needs creation
   metadata:
@@ -2070,7 +2070,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "15"
+    resourceVersion: "18"
   lastTimestamp: null
   message: Created YT object strawberry-controller (*v1.Deployment)
   metadata:
@@ -2089,7 +2089,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "15"
+    resourceVersion: "18"
   lastTimestamp: null
   message: Config strawberry-controller.yson needs creation
   metadata:
@@ -2108,7 +2108,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "15"
+    resourceVersion: "18"
   lastTimestamp: null
   message: Created YT object yt-strawberry-controller-config (*v1.ConfigMap)
   metadata:
@@ -2127,7 +2127,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "15"
+    resourceVersion: "18"
   lastTimestamp: null
   message: Created YT object strawberry (*v1.Service)
   metadata:

--- a/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "18"
+  resourceVersion: "21"
 spec:
   adminCredentials:
     name: test-ytsaurus-admin

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/Events.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/Events.yaml
@@ -101,7 +101,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -120,7 +120,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default-config (*v1.ConfigMap)
   metadata:
@@ -139,7 +139,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "3"
+    resourceVersion: "4"
   lastTimestamp: null
   message: Created YT object yt-master-init-job-default (*v1.Job)
   metadata:
@@ -158,7 +158,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object hp (*v1.StatefulSet)
   metadata:
@@ -177,7 +177,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-http-proxy.yson needs creation
   metadata:
@@ -196,7 +196,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-config (*v1.ConfigMap)
   metadata:
@@ -215,7 +215,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object http-proxies (*v1.Service)
   metadata:
@@ -234,7 +234,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-http-proxy-monitoring (*v1.Service)
   metadata:
@@ -253,7 +253,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object ds (*v1.StatefulSet)
   metadata:
@@ -272,7 +272,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-discovery.yson needs creation
   metadata:
@@ -291,7 +291,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-config (*v1.ConfigMap)
   metadata:
@@ -310,7 +310,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object discovery (*v1.Service)
   metadata:
@@ -329,7 +329,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-discovery-monitoring (*v1.Service)
   metadata:
@@ -348,7 +348,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object end (*v1.StatefulSet)
   metadata:
@@ -367,7 +367,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Config ytserver-exec-node.yson needs creation
   metadata:
@@ -386,7 +386,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-config (*v1.ConfigMap)
   metadata:
@@ -405,7 +405,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object exec-nodes (*v1.Service)
   metadata:
@@ -424,7 +424,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "5"
+    resourceVersion: "6"
   lastTimestamp: null
   message: Created YT object yt-exec-node-monitoring (*v1.Service)
   metadata:
@@ -443,7 +443,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "6"
+    resourceVersion: "7"
   lastTimestamp: null
   message: Created YT object http-proxies-lb (*v1.Service)
   metadata:
@@ -462,7 +462,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "9"
+    resourceVersion: "10"
   lastTimestamp: null
   message: Created YT object yt-client-secret (*v1.Secret)
   metadata:
@@ -481,7 +481,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Config client.yson needs creation
   metadata:
@@ -500,7 +500,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user-config (*v1.ConfigMap)
   metadata:
@@ -519,7 +519,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "10"
+    resourceVersion: "12"
   lastTimestamp: null
   message: Created YT object yt-client-init-job-user (*v1.Job)
   metadata:
@@ -538,7 +538,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Created YT object yt-cypress-patch (*v1.ConfigMap)
   metadata:
@@ -557,7 +557,7 @@
     kind: Ytsaurus
     name: test-ytsaurus
     namespace: ytsaurus-components
-    resourceVersion: "12"
+    resourceVersion: "14"
   lastTimestamp: null
   message: Skip patch apply in test
   metadata:

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/Ytsaurus.yaml
@@ -2,7 +2,7 @@ metadata:
   generation: 1
   name: test-ytsaurus
   namespace: ytsaurus-components
-  resourceVersion: "15"
+  resourceVersion: "17"
 spec:
   clusterFeatures: {}
   coreImage: ghcr.io/ytsaurus/ytsaurus:stable-25.2.2


### PR DESCRIPTION
Set condition reason between removing previous and starting new job.
This prevents restating already started job if status is stale.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
